### PR TITLE
add comments

### DIFF
--- a/cluster/options.go
+++ b/cluster/options.go
@@ -12,8 +12,11 @@ import (
 type Distribution uint8
 
 const (
+	// DistributionDefault uses the package default distribution.
 	DistributionDefault Distribution = iota
+	// DistributionModula maps keys by hash(key) % serverCount.
 	DistributionModula
+	// DistributionConsistent maps keys with a consistent-hash ring.
 	DistributionConsistent
 )
 
@@ -21,11 +24,15 @@ const (
 type Hash uint8
 
 const (
+	// HashDefault uses the package default hash.
 	HashDefault Hash = iota
+	// HashMD5 uses MD5-based hashing.
 	HashMD5
+	// HashCRC32 uses CRC32 hashing.
 	HashCRC32
 )
 
+// ClusterOption configures Cluster behavior.
 type ClusterOption func(*clusterConfig) error
 
 type clusterConfig struct {
@@ -48,6 +55,7 @@ func defaultClusterConfig() clusterConfig {
 	}
 }
 
+// WithBaseClientOptions applies base mcturbo options to all shard clients.
 func WithBaseClientOptions(opts ...mcturbo.Option) ClusterOption {
 	return func(c *clusterConfig) error {
 		c.baseClientOptions = append([]mcturbo.Option(nil), opts...)
@@ -55,6 +63,7 @@ func WithBaseClientOptions(opts ...mcturbo.Option) ClusterOption {
 	}
 }
 
+// WithVnodeFactor sets virtual-node factor for consistent hashing.
 func WithVnodeFactor(n int) ClusterOption {
 	return func(c *clusterConfig) error {
 		if n <= 0 {
@@ -65,6 +74,7 @@ func WithVnodeFactor(n int) ClusterOption {
 	}
 }
 
+// WithDistribution sets key distribution strategy.
 func WithDistribution(d Distribution) ClusterOption {
 	return func(c *clusterConfig) error {
 		switch d {
@@ -77,6 +87,7 @@ func WithDistribution(d Distribution) ClusterOption {
 	}
 }
 
+// WithHash sets key hash algorithm.
 func WithHash(h Hash) ClusterOption {
 	return func(c *clusterConfig) error {
 		switch h {
@@ -89,6 +100,8 @@ func WithHash(h Hash) ClusterOption {
 	}
 }
 
+// WithLibketamaCompatible enables libketama-compatible behavior.
+// When enabled, distribution is forced to consistent and hash is forced to MD5.
 func WithLibketamaCompatible(enabled bool) ClusterOption {
 	return func(c *clusterConfig) error {
 		c.libketamaCompatible = enabled


### PR DESCRIPTION
This pull request adds comprehensive documentation in the form of Go doc comments to the public API and option types across both the core client (`client.go`) and cluster (`cluster.go`, `options.go`) packages. This improves code readability and makes the API much easier to understand and use for other developers. No functional or behavioral changes are introduced.

The most important changes are:

**Client Package Documentation Improvements:**
- Added Go doc comments to all exported error variables, types, option functions, and all public methods in the `Client` struct, clarifying their purpose and usage. (`client.go`) [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR19-R32) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR58) [[3]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR69) [[4]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR81-R82) [[5]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR93) [[6]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR104-R112) [[7]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR134) [[8]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR174-R182) [[9]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR194) [[10]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR203) [[11]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR215) [[12]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR226) [[13]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR241) [[14]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR253) [[15]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR268)

**Cluster Package Documentation Improvements:**
- Added Go doc comments to all exported error variables, types, the `Server` struct and its fields, the `Cluster` struct, and all public methods, including context and no-context variants. (`cluster.go`) [[1]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R13-R21) [[2]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4L42-R46) [[3]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R62) [[4]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R85) [[5]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R94) [[6]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R103) [[7]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R112) [[8]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R121) [[9]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R130) [[10]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R139) [[11]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R148) [[12]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R157-R177) [[13]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R187)

**Cluster Options Documentation:**
- Added Go doc comments to all exported constants, types, and option functions related to cluster configuration, explaining distribution strategies, hash algorithms, and compatibility options. (`options.go`) [[1]](diffhunk://#diff-322ce121f830a2a52f07885d1c3102d920c54e32ce76ec3570bea60b0de6f5ceR15-R35) [[2]](diffhunk://#diff-322ce121f830a2a52f07885d1c3102d920c54e32ce76ec3570bea60b0de6f5ceR58-R66) [[3]](diffhunk://#diff-322ce121f830a2a52f07885d1c3102d920c54e32ce76ec3570bea60b0de6f5ceR77) [[4]](diffhunk://#diff-322ce121f830a2a52f07885d1c3102d920c54e32ce76ec3570bea60b0de6f5ceR90) [[5]](diffhunk://#diff-322ce121f830a2a52f07885d1c3102d920c54e32ce76ec3570bea60b0de6f5ceR103-R104)

These documentation improvements will help both current and future developers understand and use the API more effectively.