### PR TITLE
Add Incr and Decr commands with context support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It provides:
 ## Scope
 
 - Protocol: memcached ASCII only
-- Supported commands: `get`, `set`, `delete`, `touch`
+- Supported commands: `get`, `set`, `delete`, `touch`, `incr`, `decr`
 - Not in scope: binary protocol, SASL, compression, serializer
 
 ## Single-Server Client
@@ -21,12 +21,16 @@ Fast path (no context):
 - `Set(key string, value []byte, ttlSeconds int)`
 - `Delete(key string)`
 - `Touch(key string, ttlSeconds int)`
+- `Incr(key string, delta uint64)`
+- `Decr(key string, delta uint64)`
 
 Context-aware path:
 - `GetWithContext(ctx context.Context, key string)`
 - `SetWithContext(ctx context.Context, key string, value []byte, ttlSeconds int)`
 - `DeleteWithContext(ctx context.Context, key string)`
 - `TouchWithContext(ctx context.Context, key string, ttlSeconds int)`
+- `IncrWithContext(ctx context.Context, key string, delta uint64)`
+- `DecrWithContext(ctx context.Context, key string, delta uint64)`
 
 Lifecycle:
 - `Close()`
@@ -112,11 +116,11 @@ func main() {
 ### Cluster APIs
 
 Context-aware path:
-- `GetWithContext`, `SetWithContext`, `DeleteWithContext`, `TouchWithContext`
+- `GetWithContext`, `SetWithContext`, `DeleteWithContext`, `TouchWithContext`, `IncrWithContext`, `DecrWithContext`
 
 Fast path:
-- `Get`, `Set`, `Delete`, `Touch`
-- Explicit aliases: `GetNoContext`, `SetNoContext`, `DeleteNoContext`, `TouchNoContext`
+- `Get`, `Set`, `Delete`, `Touch`, `Incr`, `Decr`
+- Explicit aliases: `GetNoContext`, `SetNoContext`, `DeleteNoContext`, `TouchNoContext`, `IncrNoContext`, `DecrNoContext`
 
 Management:
 - `UpdateServers([]Server)`

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -138,3 +138,36 @@ func TestIntegrationContextDeadline(t *testing.T) {
 		t.Fatalf("expected deadline exceeded, got %v", err)
 	}
 }
+
+func TestIntegrationIncrDecr(t *testing.T) {
+	c := newIntegrationClient(t)
+	defer c.Close()
+
+	if err := c.Set("int:counter", []byte("10"), 10); err != nil {
+		t.Fatalf("set counter: %v", err)
+	}
+	n, err := c.Incr("int:counter", 5)
+	if err != nil {
+		t.Fatalf("incr: %v", err)
+	}
+	if n != 15 {
+		t.Fatalf("unexpected incr value: %d", n)
+	}
+	n, err = c.Decr("int:counter", 4)
+	if err != nil {
+		t.Fatalf("decr: %v", err)
+	}
+	if n != 11 {
+		t.Fatalf("unexpected decr value: %d", n)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	n, err = c.IncrWithContext(ctx, "int:counter", 1)
+	if err != nil {
+		t.Fatalf("incr with context: %v", err)
+	}
+	if n != 12 {
+		t.Fatalf("unexpected incr with context value: %d", n)
+	}
+}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -27,10 +27,14 @@ type shardClient interface {
 	Set(key string, value []byte, ttlSeconds int) error
 	Delete(key string) error
 	Touch(key string, ttlSeconds int) error
+	Incr(key string, delta uint64) (uint64, error)
+	Decr(key string, delta uint64) (uint64, error)
 	GetWithContext(ctx context.Context, key string) ([]byte, error)
 	SetWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error
 	DeleteWithContext(ctx context.Context, key string) error
 	TouchWithContext(ctx context.Context, key string, ttlSeconds int) error
+	IncrWithContext(ctx context.Context, key string, delta uint64) (uint64, error)
+	DecrWithContext(ctx context.Context, key string, delta uint64) (uint64, error)
 	Close() error
 }
 
@@ -118,6 +122,24 @@ func (c *Cluster) Touch(key string, ttlSeconds int) error {
 	return shard.Touch(key, ttlSeconds)
 }
 
+// Incr increments a numeric value by delta and returns the new value.
+func (c *Cluster) Incr(key string, delta uint64) (uint64, error) {
+	shard, err := c.pickShard(key)
+	if err != nil {
+		return 0, err
+	}
+	return shard.Incr(key, delta)
+}
+
+// Decr decrements a numeric value by delta and returns the new value.
+func (c *Cluster) Decr(key string, delta uint64) (uint64, error) {
+	shard, err := c.pickShard(key)
+	if err != nil {
+		return 0, err
+	}
+	return shard.Decr(key, delta)
+}
+
 // GetWithContext returns the value for key using ctx.
 func (c *Cluster) GetWithContext(ctx context.Context, key string) ([]byte, error) {
 	shard, err := c.pickShard(key)
@@ -154,6 +176,24 @@ func (c *Cluster) TouchWithContext(ctx context.Context, key string, ttlSeconds i
 	return shard.TouchWithContext(ctx, key, ttlSeconds)
 }
 
+// IncrWithContext increments a numeric value by delta and returns the new value.
+func (c *Cluster) IncrWithContext(ctx context.Context, key string, delta uint64) (uint64, error) {
+	shard, err := c.pickShard(key)
+	if err != nil {
+		return 0, err
+	}
+	return shard.IncrWithContext(ctx, key, delta)
+}
+
+// DecrWithContext decrements a numeric value by delta and returns the new value.
+func (c *Cluster) DecrWithContext(ctx context.Context, key string, delta uint64) (uint64, error) {
+	shard, err := c.pickShard(key)
+	if err != nil {
+		return 0, err
+	}
+	return shard.DecrWithContext(ctx, key, delta)
+}
+
 // GetNoContext is an explicit no-context alias of Get.
 func (c *Cluster) GetNoContext(key string) ([]byte, error) {
 	return c.Get(key)
@@ -172,6 +212,16 @@ func (c *Cluster) DeleteNoContext(key string) error {
 // TouchNoContext is an explicit no-context alias of Touch.
 func (c *Cluster) TouchNoContext(key string, ttlSeconds int) error {
 	return c.Touch(key, ttlSeconds)
+}
+
+// IncrNoContext is an explicit no-context alias of Incr.
+func (c *Cluster) IncrNoContext(key string, delta uint64) (uint64, error) {
+	return c.Incr(key, delta)
+}
+
+// DecrNoContext is an explicit no-context alias of Decr.
+func (c *Cluster) DecrNoContext(key string, delta uint64) (uint64, error) {
+	return c.Decr(key, delta)
 }
 
 // UpdateServers updates cluster servers and rebuilds routing.

--- a/cluster/cluster_integration_test.go
+++ b/cluster/cluster_integration_test.go
@@ -139,6 +139,27 @@ func TestIntegrationConsistentSetGet(t *testing.T) {
 	if _, err := c.GetNoContext("cluster:consistent:nc"); err != nil {
 		t.Fatalf("get no context: %v", err)
 	}
+
+	if err := c.SetNoContext("cluster:consistent:counter", []byte("10"), 5); err != nil {
+		t.Fatalf("set counter: %v", err)
+	}
+	n, err := c.IncrNoContext("cluster:consistent:counter", 2)
+	if err != nil {
+		t.Fatalf("incr no context: %v", err)
+	}
+	if n != 12 {
+		t.Fatalf("unexpected incr value: %d", n)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	n, err = c.DecrWithContext(ctx, "cluster:consistent:counter", 3)
+	if err != nil {
+		t.Fatalf("decr with context: %v", err)
+	}
+	if n != 9 {
+		t.Fatalf("unexpected decr value: %d", n)
+	}
 }
 
 func TestIntegrationPickDeterministic(t *testing.T) {


### PR DESCRIPTION
This pull request adds support for the `incr` and `decr` commands to the memcached client, enabling increment and decrement operations for numeric values. The changes include new client and cluster API methods, protocol handling, and comprehensive tests to ensure correct behavior for both context-aware and fast-path operations.

### New command support

* Added `Incr` and `Decr` methods (including context-aware versions) to the `Client` and `Cluster` APIs, allowing numeric values to be incremented and decremented. (`client.go`, `cluster/cluster.go`) [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL211-R238) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL264-R321) [[3]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R125-R142) [[4]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R179-R196)
* Updated the ASCII protocol handling to support `incr` and `decr` commands, including request formatting and response parsing. (`client.go`) [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR681-R710) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR726-R727) [[3]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR834-R853) [[4]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR935-R980)

### API and interface updates

* Extended the `shardClient` interface to include `Incr`, `Decr`, `IncrWithContext`, and `DecrWithContext` methods. (`cluster/cluster.go`)
* Added explicit no-context aliases for increment and decrement operations in the cluster API. (`cluster/cluster.go`)

### Documentation

* Updated `README.md` to list the new supported commands and document the new API methods for both single-server and cluster clients. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24-R33) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L115-R123)

### Testing

* Added new integration and unit tests for `incr` and `decr` operations, covering both context-aware and fast-path methods. (`client_test.go`, `client_integration_test.go`, `cluster/cluster_integration_test.go`) [[1]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3R205-R237) [[2]](diffhunk://#diff-c1001b7ecdafb4bf9f7b1fff49a1687e7aebf34656417ee4e830a9981f860b55R141-R173) [[3]](diffhunk://#diff-7c1b719b760ff01236e64052990c7e4c746868b9f93b6997bb60c064570ca30eR142-R162)

### Internal refactoring

* Modified internal request and response handling to support the new commands, including changes to the `request` struct and related methods. (`client.go`) [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL280-R350) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL179-R179) [[3]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL190-R190) [[4]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL199-R199) [[5]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL223-R247) [[6]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL237-R261) [[7]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL249-R273)

These changes collectively enable robust increment and decrement functionality for numeric values in memcached, with full support across client, cluster, and test suites.