### PR TITLE
extend memcache client and cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It provides:
 ## Scope
 
 - Protocol: memcached ASCII only
-- Supported commands: `get`, `set`, `delete`, `touch`, `incr`, `decr`
+- Supported commands: `get`, `set`, `delete`, `touch`
 - Not in scope: binary protocol, SASL, compression, serializer
 
 ## Single-Server Client
@@ -19,18 +19,32 @@ It provides:
 Fast path (no context):
 - `Get(key string)`
 - `Set(key string, value []byte, ttlSeconds int)`
+- `Add(key string, value []byte, ttlSeconds int)`
+- `Replace(key string, value []byte, ttlSeconds int)`
+- `Append(key string, value []byte)`
+- `Prepend(key string, value []byte)`
 - `Delete(key string)`
 - `Touch(key string, ttlSeconds int)`
+- `GetAndTouch(key string, ttlSeconds int)`
 - `Incr(key string, delta uint64)`
 - `Decr(key string, delta uint64)`
+- `FlushAll()`
+- `Ping()`
 
 Context-aware path:
 - `GetWithContext(ctx context.Context, key string)`
 - `SetWithContext(ctx context.Context, key string, value []byte, ttlSeconds int)`
+- `AddWithContext(ctx context.Context, key string, value []byte, ttlSeconds int)`
+- `ReplaceWithContext(ctx context.Context, key string, value []byte, ttlSeconds int)`
+- `AppendWithContext(ctx context.Context, key string, value []byte)`
+- `PrependWithContext(ctx context.Context, key string, value []byte)`
 - `DeleteWithContext(ctx context.Context, key string)`
 - `TouchWithContext(ctx context.Context, key string, ttlSeconds int)`
+- `GetAndTouchWithContext(ctx context.Context, key string, ttlSeconds int)`
 - `IncrWithContext(ctx context.Context, key string, delta uint64)`
 - `DecrWithContext(ctx context.Context, key string, delta uint64)`
+- `FlushAllWithContext(ctx context.Context)`
+- `PingWithContext(ctx context.Context)`
 
 Lifecycle:
 - `Close()`
@@ -116,11 +130,11 @@ func main() {
 ### Cluster APIs
 
 Context-aware path:
-- `GetWithContext`, `SetWithContext`, `DeleteWithContext`, `TouchWithContext`, `IncrWithContext`, `DecrWithContext`
+- `GetWithContext`, `SetWithContext`, `DeleteWithContext`, `TouchWithContext`
 
 Fast path:
-- `Get`, `Set`, `Delete`, `Touch`, `Incr`, `Decr`
-- Explicit aliases: `GetNoContext`, `SetNoContext`, `DeleteNoContext`, `TouchNoContext`, `IncrNoContext`, `DecrNoContext`
+- `Get`, `Set`, `Add`, `Replace`, `Append`, `Prepend`, `Delete`, `Touch`, `GetAndTouch`, `Incr`, `Decr`
+- Explicit aliases: `GetNoContext`, `SetNoContext`, `AddNoContext`, `ReplaceNoContext`, `AppendNoContext`, `PrependNoContext`, `DeleteNoContext`, `TouchNoContext`, `GetAndTouchNoContext`, `IncrNoContext`, `DecrNoContext`
 
 Management:
 - `UpdateServers([]Server)`

--- a/cluster/cluster_integration_test.go
+++ b/cluster/cluster_integration_test.go
@@ -127,6 +127,26 @@ func TestIntegrationModulaSetGet(t *testing.T) {
 	if string(v) != "ctx-v" {
 		t.Fatalf("unexpected value: %q", string(v))
 	}
+
+	if err := c.AddNoContext("cluster:modula:add", []byte("a"), 5); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := c.ReplaceNoContext("cluster:modula:add", []byte("b"), 5); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	if err := c.AppendNoContext("cluster:modula:add", []byte("x")); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := c.PrependNoContext("cluster:modula:add", []byte("y")); err != nil {
+		t.Fatalf("prepend: %v", err)
+	}
+	v, err = c.GetAndTouchNoContext("cluster:modula:add", 6)
+	if err != nil {
+		t.Fatalf("get and touch: %v", err)
+	}
+	if string(v) != "ybx" {
+		t.Fatalf("unexpected merged value: %q", string(v))
+	}
 }
 
 func TestIntegrationConsistentSetGet(t *testing.T) {


### PR DESCRIPTION
This pull request introduces extended Memcached-style commands to the cluster client, providing support for additional storage and counter operations (such as `Add`, `Replace`, `Append`, `Prepend`, `GetAndTouch`, `Incr`, `Decr`, `FlushAll`, and `Ping`) with both context-aware and fast-path variants. The changes also include comprehensive updates to documentation, tests, and internal interfaces to support and verify these new operations.

The most important changes are:

### API and Interface Extensions

* Added new methods to the `shardClient` interface and the `Cluster` struct for `Add`, `Replace`, `Append`, `Prepend`, `GetAndTouch`, `Incr`, and `Decr`, as well as their context-aware (`WithContext`) and explicit no-context (`NoContext`) variants. This enables more granular and atomic operations on cache entries. [[1]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R28-R47) [[2]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R117-R152) [[3]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R171-R197) [[4]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R216-R251) [[5]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R270-R296) [[6]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R307-R326) [[7]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R337-R351)

### Documentation Updates

* Updated the `README.md` to document the new methods and their variants, ensuring users are aware of the extended API surface. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22-R47) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L118-R137)

### Testing Enhancements

* Expanded integration and unit tests to cover the new commands, including scenarios for `Add`, `Replace`, `Append`, `Prepend`, `GetAndTouch`, `Incr`, `Decr`, `FlushAll`, and `Ping`, both in the main client and the cluster client. [[1]](diffhunk://#diff-c1001b7ecdafb4bf9f7b1fff49a1687e7aebf34656417ee4e830a9981f860b55R141-R217) [[2]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3R77-R84) [[3]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3R97-R136) [[4]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3R183-R241) [[5]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3R258-R283) [[6]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3R301-R340) [[7]](diffhunk://#diff-7c1b719b760ff01236e64052990c7e4c746868b9f93b6997bb60c064570ca30eR130-R149)

### Test Infrastructure Improvements

* Enhanced the fake shard implementation in tests to support and track the new commands, allowing for more thorough and accurate testing of cluster behavior. [[1]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeR18-R33) [[2]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeR70-R120)