### PR TITLE
Add GetMulti method with partial failure support and Item return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Fast path (no context):
 
 Context-aware path:
 - `GetWithContext(ctx context.Context, key string)`
+- `GetMulti(ctx context.Context, keys []string)`
 - `SetWithContext(ctx context.Context, key string, value []byte, ttlSeconds int)`
 - `AddWithContext(ctx context.Context, key string, value []byte, ttlSeconds int)`
 - `ReplaceWithContext(ctx context.Context, key string, value []byte, ttlSeconds int)`

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -87,8 +87,8 @@ func TestIntegrationSetGetDeleteTTL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	if string(v) != "abc" {
-		t.Fatalf("value mismatch: %q", string(v))
+	if string(v.Value) != "abc" {
+		t.Fatalf("value mismatch: %q", string(v.Value))
 	}
 
 	if err := c.Delete("int:key1"); err != nil {
@@ -123,7 +123,7 @@ func TestIntegrationLargeAndMultilineValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get large: %v", err)
 	}
-	if !bytes.Equal(got, payload) {
+	if !bytes.Equal(got.Value, payload) {
 		t.Fatalf("payload mismatch")
 	}
 }
@@ -196,8 +196,8 @@ func TestIntegrationExtendedStoreCommands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	if string(v) != "yrx" {
-		t.Fatalf("unexpected merged value: %q", string(v))
+	if string(v.Value) != "yrx" {
+		t.Fatalf("unexpected merged value: %q", string(v.Value))
 	}
 
 	if _, err := c.GetAndTouch("int:add", 10); err != nil {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -23,7 +23,7 @@ type Server struct {
 }
 
 type shardClient interface {
-	Get(key string) ([]byte, error)
+	Get(key string) (*mcturbo.Item, error)
 	Set(key string, value []byte, ttlSeconds int) error
 	Add(key string, value []byte, ttlSeconds int) error
 	Replace(key string, value []byte, ttlSeconds int) error
@@ -31,10 +31,10 @@ type shardClient interface {
 	Prepend(key string, value []byte) error
 	Delete(key string) error
 	Touch(key string, ttlSeconds int) error
-	GetAndTouch(key string, ttlSeconds int) ([]byte, error)
+	GetAndTouch(key string, ttlSeconds int) (*mcturbo.Item, error)
 	Incr(key string, delta uint64) (uint64, error)
 	Decr(key string, delta uint64) (uint64, error)
-	GetWithContext(ctx context.Context, key string) ([]byte, error)
+	GetWithContext(ctx context.Context, key string) (*mcturbo.Item, error)
 	SetWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error
 	AddWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error
 	ReplaceWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error
@@ -42,7 +42,7 @@ type shardClient interface {
 	PrependWithContext(ctx context.Context, key string, value []byte) error
 	DeleteWithContext(ctx context.Context, key string) error
 	TouchWithContext(ctx context.Context, key string, ttlSeconds int) error
-	GetAndTouchWithContext(ctx context.Context, key string, ttlSeconds int) ([]byte, error)
+	GetAndTouchWithContext(ctx context.Context, key string, ttlSeconds int) (*mcturbo.Item, error)
 	IncrWithContext(ctx context.Context, key string, delta uint64) (uint64, error)
 	DecrWithContext(ctx context.Context, key string, delta uint64) (uint64, error)
 	Close() error
@@ -97,7 +97,7 @@ func NewCluster(servers []Server, opts ...ClusterOption) (*Cluster, error) {
 }
 
 // Get returns the value for key.
-func (c *Cluster) Get(key string) ([]byte, error) {
+func (c *Cluster) Get(key string) (*mcturbo.Item, error) {
 	shard, err := c.pickShard(key)
 	if err != nil {
 		return nil, err
@@ -169,7 +169,7 @@ func (c *Cluster) Touch(key string, ttlSeconds int) error {
 }
 
 // GetAndTouch gets key and updates key expiration to ttlSeconds.
-func (c *Cluster) GetAndTouch(key string, ttlSeconds int) ([]byte, error) {
+func (c *Cluster) GetAndTouch(key string, ttlSeconds int) (*mcturbo.Item, error) {
 	shard, err := c.pickShard(key)
 	if err != nil {
 		return nil, err
@@ -196,7 +196,7 @@ func (c *Cluster) Decr(key string, delta uint64) (uint64, error) {
 }
 
 // GetWithContext returns the value for key using ctx.
-func (c *Cluster) GetWithContext(ctx context.Context, key string) ([]byte, error) {
+func (c *Cluster) GetWithContext(ctx context.Context, key string) (*mcturbo.Item, error) {
 	shard, err := c.pickShard(key)
 	if err != nil {
 		return nil, err
@@ -268,7 +268,7 @@ func (c *Cluster) TouchWithContext(ctx context.Context, key string, ttlSeconds i
 }
 
 // GetAndTouchWithContext gets key and updates key expiration to ttlSeconds.
-func (c *Cluster) GetAndTouchWithContext(ctx context.Context, key string, ttlSeconds int) ([]byte, error) {
+func (c *Cluster) GetAndTouchWithContext(ctx context.Context, key string, ttlSeconds int) (*mcturbo.Item, error) {
 	shard, err := c.pickShard(key)
 	if err != nil {
 		return nil, err
@@ -295,7 +295,7 @@ func (c *Cluster) DecrWithContext(ctx context.Context, key string, delta uint64)
 }
 
 // GetNoContext is an explicit no-context alias of Get.
-func (c *Cluster) GetNoContext(key string) ([]byte, error) {
+func (c *Cluster) GetNoContext(key string) (*mcturbo.Item, error) {
 	return c.Get(key)
 }
 
@@ -335,7 +335,7 @@ func (c *Cluster) TouchNoContext(key string, ttlSeconds int) error {
 }
 
 // GetAndTouchNoContext is an explicit no-context alias of GetAndTouch.
-func (c *Cluster) GetAndTouchNoContext(key string, ttlSeconds int) ([]byte, error) {
+func (c *Cluster) GetAndTouchNoContext(key string, ttlSeconds int) (*mcturbo.Item, error) {
 	return c.GetAndTouch(key, ttlSeconds)
 }
 

--- a/cluster/cluster_integration_test.go
+++ b/cluster/cluster_integration_test.go
@@ -111,8 +111,8 @@ func TestIntegrationModulaSetGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get no context: %v", err)
 	}
-	if string(v) != "nc-v" {
-		t.Fatalf("unexpected value: %q", string(v))
+	if string(v.Value) != "nc-v" {
+		t.Fatalf("unexpected value: %q", string(v.Value))
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -124,8 +124,8 @@ func TestIntegrationModulaSetGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get with context: %v", err)
 	}
-	if string(v) != "ctx-v" {
-		t.Fatalf("unexpected value: %q", string(v))
+	if string(v.Value) != "ctx-v" {
+		t.Fatalf("unexpected value: %q", string(v.Value))
 	}
 
 	if err := c.AddNoContext("cluster:modula:add", []byte("a"), 5); err != nil {
@@ -144,8 +144,8 @@ func TestIntegrationModulaSetGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get and touch: %v", err)
 	}
-	if string(v) != "ybx" {
-		t.Fatalf("unexpected merged value: %q", string(v))
+	if string(v.Value) != "ybx" {
+		t.Fatalf("unexpected merged value: %q", string(v.Value))
 	}
 }
 

--- a/cluster/cluster_more_test.go
+++ b/cluster/cluster_more_test.go
@@ -44,7 +44,7 @@ type fakeShard struct {
 	closed bool
 }
 
-func (s *fakeShard) Get(key string) ([]byte, error) {
+func (s *fakeShard) Get(key string) (*mcturbo.Item, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.getCount++
@@ -52,7 +52,7 @@ func (s *fakeShard) Get(key string) ([]byte, error) {
 	if s.getErr != nil {
 		return nil, s.getErr
 	}
-	return append([]byte(nil), s.value...), nil
+	return &mcturbo.Item{Value: append([]byte(nil), s.value...)}, nil
 }
 
 func (s *fakeShard) Set(key string, value []byte, ttlSeconds int) error {
@@ -140,14 +140,14 @@ func (s *fakeShard) Touch(key string, ttlSeconds int) error {
 	return nil
 }
 
-func (s *fakeShard) GetAndTouch(key string, ttlSeconds int) ([]byte, error) {
+func (s *fakeShard) GetAndTouch(key string, ttlSeconds int) (*mcturbo.Item, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.last = fmt.Sprintf("GetAndTouch:%s:%d", key, ttlSeconds)
 	if s.getErr != nil {
 		return nil, s.getErr
 	}
-	return append([]byte(nil), s.value...), nil
+	return &mcturbo.Item{Value: append([]byte(nil), s.value...)}, nil
 }
 
 func (s *fakeShard) Incr(key string, delta uint64) (uint64, error) {
@@ -175,7 +175,7 @@ func (s *fakeShard) Decr(key string, delta uint64) (uint64, error) {
 	return delta - 1, nil
 }
 
-func (s *fakeShard) GetWithContext(ctx context.Context, key string) ([]byte, error) {
+func (s *fakeShard) GetWithContext(ctx context.Context, key string) (*mcturbo.Item, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.getWithContextCount++
@@ -183,7 +183,7 @@ func (s *fakeShard) GetWithContext(ctx context.Context, key string) ([]byte, err
 	if s.ctxErr != nil {
 		return nil, s.ctxErr
 	}
-	return append([]byte(nil), s.value...), nil
+	return &mcturbo.Item{Value: append([]byte(nil), s.value...)}, nil
 }
 
 func (s *fakeShard) SetWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error {
@@ -269,14 +269,14 @@ func (s *fakeShard) TouchWithContext(ctx context.Context, key string, ttlSeconds
 	return nil
 }
 
-func (s *fakeShard) GetAndTouchWithContext(ctx context.Context, key string, ttlSeconds int) ([]byte, error) {
+func (s *fakeShard) GetAndTouchWithContext(ctx context.Context, key string, ttlSeconds int) (*mcturbo.Item, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.last = fmt.Sprintf("GetAndTouchWithContext:%s:%d", key, ttlSeconds)
 	if s.ctxErr != nil {
 		return nil, s.ctxErr
 	}
-	return append([]byte(nil), s.value...), nil
+	return &mcturbo.Item{Value: append([]byte(nil), s.value...)}, nil
 }
 
 func (s *fakeShard) IncrWithContext(ctx context.Context, key string, delta uint64) (uint64, error) {


### PR DESCRIPTION
This pull request introduces support for the `GetMulti` operation (retrieving multiple keys at once) and updates the API to consistently return the `*mcturbo.Item` type for all `Get`-like methods, rather than raw byte slices. It also adds comprehensive tests for the new multi-get functionality and updates documentation and benchmarks to reflect these changes.

**API changes and enhancements:**

* Added a new `GetMulti(ctx context.Context, keys []string)` method to the API, allowing retrieval of multiple keys in a single call.
* Updated all `Get`-like methods in the cluster and shard interfaces (e.g., `Get`, `GetWithContext`, `GetAndTouch`, etc.) to return `*mcturbo.Item` instead of `[]byte`, providing more structured responses. [[1]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4L26-R45) [[2]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4L100-R100) [[3]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4L172-R172) [[4]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4L199-R199) [[5]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4L271-R271) [[6]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4L298-R298) [[7]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4L338-R338) [[8]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeL47-R55) [[9]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeL143-R150) [[10]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeL178-R186) [[11]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeL272-R279)

**Testing improvements:**

* Added new tests for `GetMulti`, covering empty input, basic multi-key retrieval, partial failures, and complete failures, to ensure robust behavior and error handling.
* Updated existing tests to expect the new `*mcturbo.Item` return type for single-key `Get` operations. [[1]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3L277-R278) [[2]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3L288-R289)

**Documentation and benchmarks:**

* Updated the main `README.md` and benchmark documentation to include the new `GetMulti` method and refreshed benchmark results to reflect the latest changes and environment. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36) [[2]](diffhunk://#diff-7fe6b01752be42136da1c4bfcc273aa482497b35192a5af3fc46027766c59ae1L9-R45)

These changes improve the API's consistency, add important multi-key retrieval functionality, and ensure the codebase is well-tested and documented for these new capabilities.