### PR TITLE
Add flags parameter to Set/Add/Replace methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ It provides:
 
 Fast path (no context):
 - `Get(key string)`
-- `Set(key string, value []byte, ttlSeconds int)`
-- `Add(key string, value []byte, ttlSeconds int)`
-- `Replace(key string, value []byte, ttlSeconds int)`
+- `Set(key string, value []byte, flags uint32, ttlSeconds int)`
+- `Add(key string, value []byte, flags uint32, ttlSeconds int)`
+- `Replace(key string, value []byte, flags uint32, ttlSeconds int)`
 - `Append(key string, value []byte)`
 - `Prepend(key string, value []byte)`
 - `Delete(key string)`
@@ -34,9 +34,9 @@ Fast path (no context):
 Context-aware path:
 - `GetWithContext(ctx context.Context, key string)`
 - `GetMulti(ctx context.Context, keys []string)`
-- `SetWithContext(ctx context.Context, key string, value []byte, ttlSeconds int)`
-- `AddWithContext(ctx context.Context, key string, value []byte, ttlSeconds int)`
-- `ReplaceWithContext(ctx context.Context, key string, value []byte, ttlSeconds int)`
+- `SetWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int)`
+- `AddWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int)`
+- `ReplaceWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int)`
 - `AppendWithContext(ctx context.Context, key string, value []byte)`
 - `PrependWithContext(ctx context.Context, key string, value []byte)`
 - `DeleteWithContext(ctx context.Context, key string)`
@@ -80,7 +80,7 @@ func main() {
 	}
 	defer c.Close()
 
-	if err := c.Set("k1", []byte("value"), 10); err != nil {
+	if err := c.Set("k1", []byte("value"), 0, 10); err != nil {
 		log.Fatal(err)
 	}
 
@@ -172,7 +172,7 @@ func main() {
 	}
 	defer c.Close()
 
-	if err := c.SetNoContext("k1", []byte("value"), 10); err != nil {
+	if err := c.SetNoContext("k1", []byte("value"), 0, 10); err != nil {
 		log.Fatal(err)
 	}
 

--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -104,7 +104,7 @@ func BenchmarkSetSmall(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			k := keysMCT[i%keyCount]
-			if err := c.Set(k, payload, 60); err != nil {
+			if err := c.Set(k, payload, 0, 60); err != nil {
 				b.Fatalf("set: %v", err)
 			}
 		}
@@ -275,7 +275,7 @@ func BenchmarkDeleteHit(b *testing.B) {
 			if err != nil && !errors.Is(err, mcturbo.ErrNotFound) {
 				b.Fatalf("delete: %v", err)
 			}
-			if err := c.Set(k, value, 60); err != nil {
+			if err := c.Set(k, value, 0, 60); err != nil {
 				b.Fatalf("set: %v", err)
 			}
 		}

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -80,7 +80,7 @@ func TestIntegrationSetGetDeleteTTL(t *testing.T) {
 	c := newIntegrationClient(t)
 	defer c.Close()
 
-	if err := c.Set("int:key1", []byte("abc"), 5); err != nil {
+	if err := c.Set("int:key1", []byte("abc"), 0, 5); err != nil {
 		t.Fatalf("set: %v", err)
 	}
 	v, err := c.Get("int:key1")
@@ -99,7 +99,7 @@ func TestIntegrationSetGetDeleteTTL(t *testing.T) {
 		t.Fatalf("expected not found after delete, got %v", err)
 	}
 
-	if err := c.Set("int:ttl", []byte("x"), 1); err != nil {
+	if err := c.Set("int:ttl", []byte("x"), 0, 1); err != nil {
 		t.Fatalf("set ttl: %v", err)
 	}
 	time.Sleep(1300 * time.Millisecond)
@@ -116,7 +116,7 @@ func TestIntegrationLargeAndMultilineValue(t *testing.T) {
 	payload := bytes.Repeat([]byte("0123456789abcdef"), 60000)
 	payload = append(payload, []byte("\nline\nvalue\n")...)
 
-	if err := c.Set("int:large", payload, 5); err != nil {
+	if err := c.Set("int:large", payload, 0, 5); err != nil {
 		t.Fatalf("set large: %v", err)
 	}
 	got, err := c.Get("int:large")
@@ -134,7 +134,7 @@ func TestIntegrationContextDeadline(t *testing.T) {
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 	defer cancel()
-	if err := c.SetWithContext(ctx, "int:past", []byte("x"), 5); !errors.Is(err, context.DeadlineExceeded) {
+	if err := c.SetWithContext(ctx, "int:past", []byte("x"), 0, 5); !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected deadline exceeded, got %v", err)
 	}
 }
@@ -143,7 +143,7 @@ func TestIntegrationIncrDecr(t *testing.T) {
 	c := newIntegrationClient(t)
 	defer c.Close()
 
-	if err := c.Set("int:counter", []byte("10"), 10); err != nil {
+	if err := c.Set("int:counter", []byte("10"), 0, 10); err != nil {
 		t.Fatalf("set counter: %v", err)
 	}
 	n, err := c.Incr("int:counter", 5)
@@ -177,13 +177,13 @@ func TestIntegrationExtendedStoreCommands(t *testing.T) {
 	defer c.Close()
 
 	_ = c.Delete("int:add")
-	if err := c.Add("int:add", []byte("a"), 10); err != nil {
+	if err := c.Add("int:add", []byte("a"), 0, 10); err != nil {
 		t.Fatalf("add: %v", err)
 	}
-	if err := c.Add("int:add", []byte("b"), 10); !errors.Is(err, ErrNotStored) {
+	if err := c.Add("int:add", []byte("b"), 0, 10); !errors.Is(err, ErrNotStored) {
 		t.Fatalf("second add should be not stored: %v", err)
 	}
-	if err := c.Replace("int:add", []byte("r"), 10); err != nil {
+	if err := c.Replace("int:add", []byte("r"), 0, 10); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 	if err := c.Append("int:add", []byte("x")); err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -252,16 +252,16 @@ func TestClientBasicCommands(t *testing.T) {
 	}
 	defer c.Close()
 
-	if err := c.Set("k1", []byte("value-1"), 10); err != nil {
+	if err := c.Set("k1", []byte("value-1"), 0, 10); err != nil {
 		t.Fatalf("set: %v", err)
 	}
-	if err := c.Add("k2", []byte("v2"), 10); err != nil {
+	if err := c.Add("k2", []byte("v2"), 0, 10); err != nil {
 		t.Fatalf("add: %v", err)
 	}
-	if err := c.Add("k2", []byte("x"), 10); !errors.Is(err, ErrNotStored) {
+	if err := c.Add("k2", []byte("x"), 0, 10); !errors.Is(err, ErrNotStored) {
 		t.Fatalf("second add should return ErrNotStored: %v", err)
 	}
-	if err := c.Replace("k2", []byte("r2"), 10); err != nil {
+	if err := c.Replace("k2", []byte("r2"), 0, 10); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 	if err := c.Append("k2", []byte("A")); err != nil {
@@ -299,7 +299,7 @@ func TestClientBasicCommands(t *testing.T) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 
-	if err := c.Set("counter", []byte("10"), 10); err != nil {
+	if err := c.Set("counter", []byte("10"), 0, 10); err != nil {
 		t.Fatalf("set counter: %v", err)
 	}
 	n, err := c.Incr("counter", 7)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -24,9 +24,9 @@ type Server struct {
 
 type shardClient interface {
 	Get(key string) (*mcturbo.Item, error)
-	Set(key string, value []byte, ttlSeconds int) error
-	Add(key string, value []byte, ttlSeconds int) error
-	Replace(key string, value []byte, ttlSeconds int) error
+	Set(key string, value []byte, flags uint32, ttlSeconds int) error
+	Add(key string, value []byte, flags uint32, ttlSeconds int) error
+	Replace(key string, value []byte, flags uint32, ttlSeconds int) error
 	Append(key string, value []byte) error
 	Prepend(key string, value []byte) error
 	Delete(key string) error
@@ -35,9 +35,9 @@ type shardClient interface {
 	Incr(key string, delta uint64) (uint64, error)
 	Decr(key string, delta uint64) (uint64, error)
 	GetWithContext(ctx context.Context, key string) (*mcturbo.Item, error)
-	SetWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error
-	AddWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error
-	ReplaceWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error
+	SetWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int) error
+	AddWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int) error
+	ReplaceWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int) error
 	AppendWithContext(ctx context.Context, key string, value []byte) error
 	PrependWithContext(ctx context.Context, key string, value []byte) error
 	DeleteWithContext(ctx context.Context, key string) error
@@ -105,31 +105,31 @@ func (c *Cluster) Get(key string) (*mcturbo.Item, error) {
 	return shard.Get(key)
 }
 
-// Set stores value for key with ttlSeconds.
-func (c *Cluster) Set(key string, value []byte, ttlSeconds int) error {
+// Set stores value for key with flags and ttlSeconds.
+func (c *Cluster) Set(key string, value []byte, flags uint32, ttlSeconds int) error {
 	shard, err := c.pickShard(key)
 	if err != nil {
 		return err
 	}
-	return shard.Set(key, value, ttlSeconds)
+	return shard.Set(key, value, flags, ttlSeconds)
 }
 
 // Add stores value for key only if key does not exist.
-func (c *Cluster) Add(key string, value []byte, ttlSeconds int) error {
+func (c *Cluster) Add(key string, value []byte, flags uint32, ttlSeconds int) error {
 	shard, err := c.pickShard(key)
 	if err != nil {
 		return err
 	}
-	return shard.Add(key, value, ttlSeconds)
+	return shard.Add(key, value, flags, ttlSeconds)
 }
 
 // Replace stores value for key only if key already exists.
-func (c *Cluster) Replace(key string, value []byte, ttlSeconds int) error {
+func (c *Cluster) Replace(key string, value []byte, flags uint32, ttlSeconds int) error {
 	shard, err := c.pickShard(key)
 	if err != nil {
 		return err
 	}
-	return shard.Replace(key, value, ttlSeconds)
+	return shard.Replace(key, value, flags, ttlSeconds)
 }
 
 // Append appends value to existing key value.
@@ -204,31 +204,31 @@ func (c *Cluster) GetWithContext(ctx context.Context, key string) (*mcturbo.Item
 	return shard.GetWithContext(ctx, key)
 }
 
-// SetWithContext stores value for key with ttlSeconds using ctx.
-func (c *Cluster) SetWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error {
+// SetWithContext stores value for key with flags and ttlSeconds using ctx.
+func (c *Cluster) SetWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int) error {
 	shard, err := c.pickShard(key)
 	if err != nil {
 		return err
 	}
-	return shard.SetWithContext(ctx, key, value, ttlSeconds)
+	return shard.SetWithContext(ctx, key, value, flags, ttlSeconds)
 }
 
 // AddWithContext stores value for key only if key does not exist.
-func (c *Cluster) AddWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error {
+func (c *Cluster) AddWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int) error {
 	shard, err := c.pickShard(key)
 	if err != nil {
 		return err
 	}
-	return shard.AddWithContext(ctx, key, value, ttlSeconds)
+	return shard.AddWithContext(ctx, key, value, flags, ttlSeconds)
 }
 
 // ReplaceWithContext stores value for key only if key already exists.
-func (c *Cluster) ReplaceWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error {
+func (c *Cluster) ReplaceWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int) error {
 	shard, err := c.pickShard(key)
 	if err != nil {
 		return err
 	}
-	return shard.ReplaceWithContext(ctx, key, value, ttlSeconds)
+	return shard.ReplaceWithContext(ctx, key, value, flags, ttlSeconds)
 }
 
 // AppendWithContext appends value to existing key value.
@@ -300,18 +300,18 @@ func (c *Cluster) GetNoContext(key string) (*mcturbo.Item, error) {
 }
 
 // SetNoContext is an explicit no-context alias of Set.
-func (c *Cluster) SetNoContext(key string, value []byte, ttlSeconds int) error {
-	return c.Set(key, value, ttlSeconds)
+func (c *Cluster) SetNoContext(key string, value []byte, flags uint32, ttlSeconds int) error {
+	return c.Set(key, value, flags, ttlSeconds)
 }
 
 // AddNoContext is an explicit no-context alias of Add.
-func (c *Cluster) AddNoContext(key string, value []byte, ttlSeconds int) error {
-	return c.Add(key, value, ttlSeconds)
+func (c *Cluster) AddNoContext(key string, value []byte, flags uint32, ttlSeconds int) error {
+	return c.Add(key, value, flags, ttlSeconds)
 }
 
 // ReplaceNoContext is an explicit no-context alias of Replace.
-func (c *Cluster) ReplaceNoContext(key string, value []byte, ttlSeconds int) error {
-	return c.Replace(key, value, ttlSeconds)
+func (c *Cluster) ReplaceNoContext(key string, value []byte, flags uint32, ttlSeconds int) error {
+	return c.Replace(key, value, flags, ttlSeconds)
 }
 
 // AppendNoContext is an explicit no-context alias of Append.

--- a/cluster/cluster_integration_test.go
+++ b/cluster/cluster_integration_test.go
@@ -104,7 +104,7 @@ func TestIntegrationModulaSetGet(t *testing.T) {
 	c := newIntegrationCluster(t, WithDistribution(DistributionModula))
 	defer c.Close()
 
-	if err := c.SetNoContext("cluster:modula:nc", []byte("nc-v"), 5); err != nil {
+	if err := c.SetNoContext("cluster:modula:nc", []byte("nc-v"), 0, 5); err != nil {
 		t.Fatalf("set no context: %v", err)
 	}
 	v, err := c.GetNoContext("cluster:modula:nc")
@@ -117,7 +117,7 @@ func TestIntegrationModulaSetGet(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := c.SetWithContext(ctx, "cluster:modula:ctx", []byte("ctx-v"), 5); err != nil {
+	if err := c.SetWithContext(ctx, "cluster:modula:ctx", []byte("ctx-v"), 0, 5); err != nil {
 		t.Fatalf("set with context: %v", err)
 	}
 	v, err = c.GetWithContext(ctx, "cluster:modula:ctx")
@@ -128,10 +128,10 @@ func TestIntegrationModulaSetGet(t *testing.T) {
 		t.Fatalf("unexpected value: %q", string(v.Value))
 	}
 
-	if err := c.AddNoContext("cluster:modula:add", []byte("a"), 5); err != nil {
+	if err := c.AddNoContext("cluster:modula:add", []byte("a"), 0, 5); err != nil {
 		t.Fatalf("add: %v", err)
 	}
-	if err := c.ReplaceNoContext("cluster:modula:add", []byte("b"), 5); err != nil {
+	if err := c.ReplaceNoContext("cluster:modula:add", []byte("b"), 0, 5); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 	if err := c.AppendNoContext("cluster:modula:add", []byte("x")); err != nil {
@@ -153,14 +153,14 @@ func TestIntegrationConsistentSetGet(t *testing.T) {
 	c := newIntegrationCluster(t, WithDistribution(DistributionConsistent), WithHash(HashMD5))
 	defer c.Close()
 
-	if err := c.SetNoContext("cluster:consistent:nc", []byte("v"), 5); err != nil {
+	if err := c.SetNoContext("cluster:consistent:nc", []byte("v"), 0, 5); err != nil {
 		t.Fatalf("set no context: %v", err)
 	}
 	if _, err := c.GetNoContext("cluster:consistent:nc"); err != nil {
 		t.Fatalf("get no context: %v", err)
 	}
 
-	if err := c.SetNoContext("cluster:consistent:counter", []byte("10"), 5); err != nil {
+	if err := c.SetNoContext("cluster:consistent:counter", []byte("10"), 0, 5); err != nil {
 		t.Fatalf("set counter: %v", err)
 	}
 	n, err := c.IncrNoContext("cluster:consistent:counter", 2)
@@ -214,7 +214,7 @@ func TestIntegrationDistribution(t *testing.T) {
 	const keyN = 120
 	for i := 0; i < keyN; i++ {
 		k := fmt.Sprintf("cluster:dist:%d", i)
-		if err := c.SetNoContext(k, []byte("v"), 30); err != nil {
+		if err := c.SetNoContext(k, []byte("v"), 0, 30); err != nil {
 			t.Fatalf("cluster set: %v", err)
 		}
 	}
@@ -260,7 +260,7 @@ func TestIntegrationUpdateServers(t *testing.T) {
 	}
 	defer c.Close()
 
-	if err := c.SetNoContext("cluster:update:before", []byte("v1"), 30); err != nil {
+	if err := c.SetNoContext("cluster:update:before", []byte("v1"), 0, 30); err != nil {
 		t.Fatalf("set before update: %v", err)
 	}
 	if _, err := c.GetNoContext("cluster:update:before"); err != nil {
@@ -273,7 +273,7 @@ func TestIntegrationUpdateServers(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := c.SetWithContext(ctx, "cluster:update:after", []byte("v2"), 30); err != nil {
+	if err := c.SetWithContext(ctx, "cluster:update:after", []byte("v2"), 0, 30); err != nil {
 		t.Fatalf("set after update: %v", err)
 	}
 	if _, err := c.GetWithContext(ctx, "cluster:update:after"); err != nil {

--- a/cluster/cluster_more_test.go
+++ b/cluster/cluster_more_test.go
@@ -55,7 +55,7 @@ func (s *fakeShard) Get(key string) (*mcturbo.Item, error) {
 	return &mcturbo.Item{Value: append([]byte(nil), s.value...)}, nil
 }
 
-func (s *fakeShard) Set(key string, value []byte, ttlSeconds int) error {
+func (s *fakeShard) Set(key string, value []byte, flags uint32, ttlSeconds int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.setCount++
@@ -67,7 +67,7 @@ func (s *fakeShard) Set(key string, value []byte, ttlSeconds int) error {
 	return nil
 }
 
-func (s *fakeShard) Add(key string, value []byte, ttlSeconds int) error {
+func (s *fakeShard) Add(key string, value []byte, flags uint32, ttlSeconds int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.addCount++
@@ -79,7 +79,7 @@ func (s *fakeShard) Add(key string, value []byte, ttlSeconds int) error {
 	return nil
 }
 
-func (s *fakeShard) Replace(key string, value []byte, ttlSeconds int) error {
+func (s *fakeShard) Replace(key string, value []byte, flags uint32, ttlSeconds int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.replaceCount++
@@ -186,7 +186,7 @@ func (s *fakeShard) GetWithContext(ctx context.Context, key string) (*mcturbo.It
 	return &mcturbo.Item{Value: append([]byte(nil), s.value...)}, nil
 }
 
-func (s *fakeShard) SetWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error {
+func (s *fakeShard) SetWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.setWithContextCount++
@@ -198,7 +198,7 @@ func (s *fakeShard) SetWithContext(ctx context.Context, key string, value []byte
 	return nil
 }
 
-func (s *fakeShard) AddWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error {
+func (s *fakeShard) AddWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.addWithContextCount++
@@ -210,7 +210,7 @@ func (s *fakeShard) AddWithContext(ctx context.Context, key string, value []byte
 	return nil
 }
 
-func (s *fakeShard) ReplaceWithContext(ctx context.Context, key string, value []byte, ttlSeconds int) error {
+func (s *fakeShard) ReplaceWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.replaceWithContextCount++
@@ -406,19 +406,19 @@ func TestClusterRoutingAndDelegation(t *testing.T) {
 		t.Fatalf("expected GetWithContext on target")
 	}
 
-	if err := c.SetNoContext(key, []byte("v1"), 10); err != nil {
+	if err := c.SetNoContext(key, []byte("v1"), 0, 10); err != nil {
 		t.Fatalf("SetNoContext: %v", err)
 	}
-	if err := c.SetWithContext(ctx, key, []byte("v2"), 11); err != nil {
+	if err := c.SetWithContext(ctx, key, []byte("v2"), 0, 11); err != nil {
 		t.Fatalf("SetWithContext: %v", err)
 	}
 	if target.setCount != 1 || target.setWithContextCount != 1 {
 		t.Fatalf("expected both set paths on target: set=%d setCtx=%d", target.setCount, target.setWithContextCount)
 	}
-	if err := c.AddNoContext(key, []byte("a"), 12); err != nil {
+	if err := c.AddNoContext(key, []byte("a"), 0, 12); err != nil {
 		t.Fatalf("AddNoContext: %v", err)
 	}
-	if err := c.ReplaceWithContext(ctx, key, []byte("b"), 13); err != nil {
+	if err := c.ReplaceWithContext(ctx, key, []byte("b"), 0, 13); err != nil {
 		t.Fatalf("ReplaceWithContext: %v", err)
 	}
 	if err := c.AppendNoContext(key, []byte("c")); err != nil {


### PR DESCRIPTION
This pull request updates the client API to support a `flags` parameter for storage operations, aligning the interface more closely with the Memcached protocol. The changes affect both the context-aware and fast-path methods, update the request handling and validation logic, and revise tests and documentation accordingly.

**API changes for storage operations:**
- Added a `flags uint32` parameter to `Set`, `Add`, and `Replace` methods (and their context-aware variants), updating their signatures and internal calls to include this new argument. (`client.go`, `README.md`) [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL285-R326) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL418-R465) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R23) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R39)
- Updated all usage sites (examples, tests, and benchmarks) to use the new method signatures with the `flags` argument. (`README.md`, `client_integration_test.go`, `benchmark/benchmark_test.go`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R83) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L175-R175) [[3]](diffhunk://#diff-c1001b7ecdafb4bf9f7b1fff49a1687e7aebf34656417ee4e830a9981f860b55L83-R83) [[4]](diffhunk://#diff-c1001b7ecdafb4bf9f7b1fff49a1687e7aebf34656417ee4e830a9981f860b55L102-R102) [[5]](diffhunk://#diff-c1001b7ecdafb4bf9f7b1fff49a1687e7aebf34656417ee4e830a9981f860b55L119-R119) [[6]](diffhunk://#diff-c1001b7ecdafb4bf9f7b1fff49a1687e7aebf34656417ee4e830a9981f860b55L137-R137) [[7]](diffhunk://#diff-c1001b7ecdafb4bf9f7b1fff49a1687e7aebf34656417ee4e830a9981f860b55L146-R146) [[8]](diffhunk://#diff-c1001b7ecdafb4bf9f7b1fff49a1687e7aebf34656417ee4e830a9981f860b55L180-R186) [[9]](diffhunk://#diff-e23064a1e36f6abc739e3c22d5e57e0a4950a70dedc4ee70a0b4bf3e2e821f2fL107-R107) [[10]](diffhunk://#diff-e23064a1e36f6abc739e3c22d5e57e0a4950a70dedc4ee70a0b4bf3e2e821f2fL278-R278)

**Internal request and validation logic:**
- Extended the `request` struct to include a `flags` field and updated all internal request construction and serialization logic to handle the `flags` parameter. (`client.go`) [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR693) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL588-R587) [[3]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL614-R608) [[4]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL1118-R1111)
- Added a `validateStoreInput` helper to centralize validation for store operations, replacing previous key/TTL validation logic. (`client.go`)

**Protocol and utility updates:**
- Modified the wire protocol serialization to correctly write the `flags` value in decimal format for storage commands. (`client.go`) [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL1118-R1111) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR1640-R1643)
- Minor docstring corrections and code cleanups for consistency in method comments and argument handling. (`client.go`) [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL285-R326) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL418-R465)

These changes ensure that the client fully supports the `flags` field required by the Memcached protocol for storage operations and that all documentation and tests reflect the updated API.