### PR TITLE
Add CAS command support with Gets and CAS methods in client

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It provides:
 ## Scope
 
 - Protocol: memcached ASCII only
-- Supported commands: `get`, `set`, `delete`, `touch`
+- Supported commands: `get`, `gets`, `set`, `add`, `replace`, `cas`, `append`, `prepend`, `delete`, `touch`, `gat`, `incr`, `decr`
 - Not in scope: binary protocol, SASL, compression, serializer
 
 ## Single-Server Client
@@ -18,9 +18,11 @@ It provides:
 
 Fast path (no context):
 - `Get(key string)`
+- `Gets(key string)`
 - `Set(key string, value []byte, flags uint32, ttlSeconds int)`
 - `Add(key string, value []byte, flags uint32, ttlSeconds int)`
 - `Replace(key string, value []byte, flags uint32, ttlSeconds int)`
+- `CAS(key string, value []byte, flags uint32, ttlSeconds int, cas uint64)`
 - `Append(key string, value []byte)`
 - `Prepend(key string, value []byte)`
 - `Delete(key string)`
@@ -33,10 +35,12 @@ Fast path (no context):
 
 Context-aware path:
 - `GetWithContext(ctx context.Context, key string)`
+- `GetsWithContext(ctx context.Context, key string)`
 - `GetMulti(ctx context.Context, keys []string)`
 - `SetWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int)`
 - `AddWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int)`
 - `ReplaceWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int)`
+- `CASWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int, cas uint64)`
 - `AppendWithContext(ctx context.Context, key string, value []byte)`
 - `PrependWithContext(ctx context.Context, key string, value []byte)`
 - `DeleteWithContext(ctx context.Context, key string)`
@@ -91,7 +95,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("value=%s", string(v))
+	log.Printf("value=%s flags=%d", string(v.Value), v.Flags)
 }
 ```
 
@@ -135,7 +139,7 @@ Context-aware path:
 
 Fast path:
 - `Get`, `Set`, `Add`, `Replace`, `Append`, `Prepend`, `Delete`, `Touch`, `GetAndTouch`, `Incr`, `Decr`
-- Explicit aliases: `GetNoContext`, `SetNoContext`, `AddNoContext`, `ReplaceNoContext`, `AppendNoContext`, `PrependNoContext`, `DeleteNoContext`, `TouchNoContext`, `GetAndTouchNoContext`, `IncrNoContext`, `DecrNoContext`
+- Explicit aliases: `GetNoContext`, `GetsNoContext`, `SetNoContext`, `AddNoContext`, `ReplaceNoContext`, `CASNoContext`, `AppendNoContext`, `PrependNoContext`, `DeleteNoContext`, `TouchNoContext`, `GetAndTouchNoContext`, `IncrNoContext`, `DecrNoContext`
 
 Management:
 - `UpdateServers([]Server)`
@@ -183,7 +187,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("value=%s", string(v))
+	log.Printf("value=%s flags=%d", string(v.Value), v.Flags)
 }
 ```
 


### PR DESCRIPTION
This pull request adds support for the full set of common ASCII memcached commands, including CAS (Check-And-Set) and related operations, and updates the API to expose CAS-aware methods. It also improves the `Item` structure to include the CAS value, introduces new error handling for CAS conflicts, and updates both the implementation and documentation to reflect these enhancements.

**New command and method support:**

- Added support for the `gets`, `cas`, `add`, `replace`, `append`, `prepend`, `gat`, `incr`, and `decr` commands, in addition to the previously supported commands. (`README.md`)
- Introduced new methods: `Gets`, `CAS`, `GetsWithContext`, and `CASWithContext`, along with their explicit no-context aliases, to allow CAS-based operations. (`client.go`, `README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R43) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L138-R142) [[4]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR220-R227) [[5]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL308-R328) [[6]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR429-R439) [[7]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL441-R484)

**API and struct enhancements:**

- Updated the `Item` struct to include a `CAS` field, enabling clients to read and use the CAS value for optimistic concurrency control. (`client.go`)
- Added a new error, `ErrCASConflict`, to signal CAS mismatches during updates. (`client.go`)

**Internal implementation updates:**

- Refactored internal request handling to support CAS and the new commands, including changes to the request struct, operation types, and request serialization. (`client.go`) [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR718-R722) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR741) [[3]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR1125-R1141) [[4]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR1151-R1152)
- Updated all relevant methods and internal helpers to accept and propagate the CAS value as needed. (`client.go`) [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL290-R301) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL299-R310) [[3]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL317-R337) [[4]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL326-R346) [[5]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL335-R355) [[6]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL347-R367) [[7]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL367-R387) [[8]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL379-R399) [[9]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL417-R448) [[10]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL429-R460) [[11]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL453-R496) [[12]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL465-R508) [[13]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL477-R520) [[14]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL492-R535) [[15]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL518-R561) [[16]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL533-R576) [[17]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL570-R618) [[18]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL600-R651)

**Documentation and example updates:**

- Updated the `README.md` to document new commands, methods, and usage examples, including showing how to access the `flags` and `CAS` fields from returned items. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R98) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L186-R190)

These changes provide more complete memcached protocol support and enable safe, concurrent updates using CAS.