### PR TITLE
Add auto-eject failover option with server health tracking to Cluster

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,6 +29,11 @@ var (
 
 var errProtocol = errors.New("memcache: protocol error")
 
+// IsProtocolError reports whether err is a protocol-level parsing/format error.
+func IsProtocolError(err error) bool {
+	return errors.Is(err, errProtocol)
+}
+
 // Item represents a value returned by get operations.
 type Item struct {
 	Value []byte

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -3,8 +3,11 @@ package cluster
 import (
 	"context"
 	"errors"
+	"io"
+	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/catatsuy/mcturbo"
 )
@@ -61,6 +64,11 @@ type clusterState struct {
 	byAddr  map[string]shardClient
 }
 
+type shardHealth struct {
+	failures  int
+	deadUntil time.Time
+}
+
 // Cluster routes keys to shard clients built from mcturbo.Client.
 type Cluster struct {
 	closed atomic.Bool
@@ -74,6 +82,10 @@ type Cluster struct {
 	distribution        Distribution
 	hash                Hash
 	libketamaCompatible bool
+	removeFailedServers bool
+	serverFailureLimit  int
+	retryTimeout        time.Duration
+	healthByAddr        map[string]*shardHealth
 	factory             shardFactory
 }
 
@@ -92,6 +104,10 @@ func NewCluster(servers []Server, opts ...ClusterOption) (*Cluster, error) {
 		distribution:        effectiveDistribution(&cfg),
 		hash:                effectiveHash(&cfg),
 		libketamaCompatible: cfg.libketamaCompatible,
+		removeFailedServers: cfg.removeFailedServers,
+		serverFailureLimit:  cfg.serverFailureLimit,
+		retryTimeout:        cfg.retryTimeout,
+		healthByAddr:        map[string]*shardHealth{},
 		factory:             cfg.factory,
 	}
 	if err := c.updateServersLocked(servers); err != nil {
@@ -102,236 +118,184 @@ func NewCluster(servers []Server, opts ...ClusterOption) (*Cluster, error) {
 
 // Get returns the value for key.
 func (c *Cluster) Get(key string) (*mcturbo.Item, error) {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return nil, err
-	}
-	return shard.Get(key)
+	return c.execItemNoContext(key, func(shard shardClient) (*mcturbo.Item, error) {
+		return shard.Get(key)
+	})
 }
 
 // Gets returns the item for key with CAS value.
 func (c *Cluster) Gets(key string) (*mcturbo.Item, error) {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return nil, err
-	}
-	return shard.Gets(key)
+	return c.execItemNoContext(key, func(shard shardClient) (*mcturbo.Item, error) {
+		return shard.Gets(key)
+	})
 }
 
 // Set stores value for key with flags and ttlSeconds.
 func (c *Cluster) Set(key string, value []byte, flags uint32, ttlSeconds int) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.Set(key, value, flags, ttlSeconds)
+	return c.execErrNoContext(key, func(shard shardClient) error {
+		return shard.Set(key, value, flags, ttlSeconds)
+	})
 }
 
 // Add stores value for key only if key does not exist.
 func (c *Cluster) Add(key string, value []byte, flags uint32, ttlSeconds int) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.Add(key, value, flags, ttlSeconds)
+	return c.execErrNoContext(key, func(shard shardClient) error {
+		return shard.Add(key, value, flags, ttlSeconds)
+	})
 }
 
 // Replace stores value for key only if key already exists.
 func (c *Cluster) Replace(key string, value []byte, flags uint32, ttlSeconds int) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.Replace(key, value, flags, ttlSeconds)
+	return c.execErrNoContext(key, func(shard shardClient) error {
+		return shard.Replace(key, value, flags, ttlSeconds)
+	})
 }
 
 // Append appends value to existing key value.
 func (c *Cluster) Append(key string, value []byte) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.Append(key, value)
+	return c.execErrNoContext(key, func(shard shardClient) error {
+		return shard.Append(key, value)
+	})
 }
 
 // Prepend prepends value to existing key value.
 func (c *Cluster) Prepend(key string, value []byte) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.Prepend(key, value)
+	return c.execErrNoContext(key, func(shard shardClient) error {
+		return shard.Prepend(key, value)
+	})
 }
 
 // Delete removes key.
 func (c *Cluster) Delete(key string) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.Delete(key)
+	return c.execErrNoContext(key, func(shard shardClient) error {
+		return shard.Delete(key)
+	})
 }
 
 // Touch updates key expiration to ttlSeconds.
 func (c *Cluster) Touch(key string, ttlSeconds int) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.Touch(key, ttlSeconds)
+	return c.execErrNoContext(key, func(shard shardClient) error {
+		return shard.Touch(key, ttlSeconds)
+	})
 }
 
 // GetAndTouch gets key and updates key expiration to ttlSeconds.
 func (c *Cluster) GetAndTouch(key string, ttlSeconds int) (*mcturbo.Item, error) {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return nil, err
-	}
-	return shard.GetAndTouch(key, ttlSeconds)
+	return c.execItemNoContext(key, func(shard shardClient) (*mcturbo.Item, error) {
+		return shard.GetAndTouch(key, ttlSeconds)
+	})
 }
 
 // Incr increments a numeric value by delta and returns the new value.
 func (c *Cluster) Incr(key string, delta uint64) (uint64, error) {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return 0, err
-	}
-	return shard.Incr(key, delta)
+	return c.execUint64NoContext(key, func(shard shardClient) (uint64, error) {
+		return shard.Incr(key, delta)
+	})
 }
 
 // Decr decrements a numeric value by delta and returns the new value.
 func (c *Cluster) Decr(key string, delta uint64) (uint64, error) {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return 0, err
-	}
-	return shard.Decr(key, delta)
+	return c.execUint64NoContext(key, func(shard shardClient) (uint64, error) {
+		return shard.Decr(key, delta)
+	})
 }
 
 // CAS stores value for key only when cas matches.
 func (c *Cluster) CAS(key string, value []byte, flags uint32, ttlSeconds int, cas uint64) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.CAS(key, value, flags, ttlSeconds, cas)
+	return c.execErrNoContext(key, func(shard shardClient) error {
+		return shard.CAS(key, value, flags, ttlSeconds, cas)
+	})
 }
 
 // GetWithContext returns the value for key using ctx.
 func (c *Cluster) GetWithContext(ctx context.Context, key string) (*mcturbo.Item, error) {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return nil, err
-	}
-	return shard.GetWithContext(ctx, key)
+	return c.execItemWithContext(ctx, key, func(shard shardClient) (*mcturbo.Item, error) {
+		return shard.GetWithContext(ctx, key)
+	})
 }
 
 // GetsWithContext returns the item for key with CAS value using ctx.
 func (c *Cluster) GetsWithContext(ctx context.Context, key string) (*mcturbo.Item, error) {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return nil, err
-	}
-	return shard.GetsWithContext(ctx, key)
+	return c.execItemWithContext(ctx, key, func(shard shardClient) (*mcturbo.Item, error) {
+		return shard.GetsWithContext(ctx, key)
+	})
 }
 
 // SetWithContext stores value for key with flags and ttlSeconds using ctx.
 func (c *Cluster) SetWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.SetWithContext(ctx, key, value, flags, ttlSeconds)
+	return c.execErrWithContext(ctx, key, func(shard shardClient) error {
+		return shard.SetWithContext(ctx, key, value, flags, ttlSeconds)
+	})
 }
 
 // AddWithContext stores value for key only if key does not exist.
 func (c *Cluster) AddWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.AddWithContext(ctx, key, value, flags, ttlSeconds)
+	return c.execErrWithContext(ctx, key, func(shard shardClient) error {
+		return shard.AddWithContext(ctx, key, value, flags, ttlSeconds)
+	})
 }
 
 // ReplaceWithContext stores value for key only if key already exists.
 func (c *Cluster) ReplaceWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.ReplaceWithContext(ctx, key, value, flags, ttlSeconds)
+	return c.execErrWithContext(ctx, key, func(shard shardClient) error {
+		return shard.ReplaceWithContext(ctx, key, value, flags, ttlSeconds)
+	})
 }
 
 // AppendWithContext appends value to existing key value.
 func (c *Cluster) AppendWithContext(ctx context.Context, key string, value []byte) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.AppendWithContext(ctx, key, value)
+	return c.execErrWithContext(ctx, key, func(shard shardClient) error {
+		return shard.AppendWithContext(ctx, key, value)
+	})
 }
 
 // PrependWithContext prepends value to existing key value.
 func (c *Cluster) PrependWithContext(ctx context.Context, key string, value []byte) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.PrependWithContext(ctx, key, value)
+	return c.execErrWithContext(ctx, key, func(shard shardClient) error {
+		return shard.PrependWithContext(ctx, key, value)
+	})
 }
 
 // DeleteWithContext removes key using ctx.
 func (c *Cluster) DeleteWithContext(ctx context.Context, key string) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.DeleteWithContext(ctx, key)
+	return c.execErrWithContext(ctx, key, func(shard shardClient) error {
+		return shard.DeleteWithContext(ctx, key)
+	})
 }
 
 // TouchWithContext updates key expiration using ctx.
 func (c *Cluster) TouchWithContext(ctx context.Context, key string, ttlSeconds int) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.TouchWithContext(ctx, key, ttlSeconds)
+	return c.execErrWithContext(ctx, key, func(shard shardClient) error {
+		return shard.TouchWithContext(ctx, key, ttlSeconds)
+	})
 }
 
 // GetAndTouchWithContext gets key and updates key expiration to ttlSeconds.
 func (c *Cluster) GetAndTouchWithContext(ctx context.Context, key string, ttlSeconds int) (*mcturbo.Item, error) {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return nil, err
-	}
-	return shard.GetAndTouchWithContext(ctx, key, ttlSeconds)
+	return c.execItemWithContext(ctx, key, func(shard shardClient) (*mcturbo.Item, error) {
+		return shard.GetAndTouchWithContext(ctx, key, ttlSeconds)
+	})
 }
 
 // IncrWithContext increments a numeric value by delta and returns the new value.
 func (c *Cluster) IncrWithContext(ctx context.Context, key string, delta uint64) (uint64, error) {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return 0, err
-	}
-	return shard.IncrWithContext(ctx, key, delta)
+	return c.execUint64WithContext(ctx, key, func(shard shardClient) (uint64, error) {
+		return shard.IncrWithContext(ctx, key, delta)
+	})
 }
 
 // DecrWithContext decrements a numeric value by delta and returns the new value.
 func (c *Cluster) DecrWithContext(ctx context.Context, key string, delta uint64) (uint64, error) {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return 0, err
-	}
-	return shard.DecrWithContext(ctx, key, delta)
+	return c.execUint64WithContext(ctx, key, func(shard shardClient) (uint64, error) {
+		return shard.DecrWithContext(ctx, key, delta)
+	})
 }
 
 // CASWithContext stores value for key only when cas matches using ctx.
 func (c *Cluster) CASWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int, cas uint64) error {
-	shard, err := c.pickShard(key)
-	if err != nil {
-		return err
-	}
-	return shard.CASWithContext(ctx, key, value, flags, ttlSeconds, cas)
+	return c.execErrWithContext(ctx, key, func(shard shardClient) error {
+		return shard.CASWithContext(ctx, key, value, flags, ttlSeconds, cas)
+	})
 }
 
 // GetNoContext is an explicit no-context alias of Get.
@@ -448,8 +412,7 @@ func (c *Cluster) updateServersLocked(servers []Server) error {
 
 	newByAddr := make(map[string]shardClient, len(normalized))
 	created := make([]shardClient, 0, len(normalized))
-	for i := range normalized {
-		srv := normalized[i]
+	for _, srv := range normalized {
 		if shard, ok := oldByAddr[srv.Addr]; ok {
 			newByAddr[srv.Addr] = shard
 			continue
@@ -466,8 +429,8 @@ func (c *Cluster) updateServersLocked(servers []Server) error {
 	}
 
 	newShards := make([]shardClient, len(normalized))
-	for i := range normalized {
-		newShards[i] = newByAddr[normalized[i].Addr]
+	for i, srv := range normalized {
+		newShards[i] = newByAddr[srv.Addr]
 	}
 
 	newState := &clusterState{
@@ -477,6 +440,17 @@ func (c *Cluster) updateServersLocked(servers []Server) error {
 		byAddr:  newByAddr,
 	}
 	c.state.Store(newState)
+
+	nextHealth := make(map[string]*shardHealth, len(normalized))
+	for _, srv := range normalized {
+		addr := srv.Addr
+		if h, ok := c.healthByAddr[addr]; ok {
+			nextHealth[addr] = h
+			continue
+		}
+		nextHealth[addr] = &shardHealth{}
+	}
+	c.healthByAddr = nextHealth
 
 	if oldState != nil {
 		for addr, shard := range oldState.byAddr {
@@ -488,27 +462,267 @@ func (c *Cluster) updateServersLocked(servers []Server) error {
 	return nil
 }
 
-func (c *Cluster) pickShard(key string) (shardClient, error) {
-	if c.closed.Load() {
-		return nil, ErrClosed
-	}
-	st := c.loadState()
-	if st == nil || st.router == nil {
-		return nil, errNoServers
-	}
-	idx := st.router.Pick(key)
-	if idx < 0 || idx >= len(st.shards) {
-		return nil, errNoServers
-	}
-	return st.shards[idx], nil
-}
-
 func (c *Cluster) loadState() *clusterState {
 	v := c.state.Load()
 	if v == nil {
 		return nil
 	}
 	return v.(*clusterState)
+}
+
+func (c *Cluster) execItemNoContext(key string, fn func(shardClient) (*mcturbo.Item, error)) (*mcturbo.Item, error) {
+	if c.closed.Load() {
+		return nil, ErrClosed
+	}
+	var last error
+	for _, cand := range c.pickCandidates(key) {
+		it, err := fn(cand.shard)
+		if err == nil {
+			c.noteSuccess(cand.addr)
+			return it, nil
+		}
+		last = err
+		c.noteFailure(cand.addr, err)
+		if !c.shouldTryNext(err) {
+			return nil, err
+		}
+	}
+	if last != nil {
+		return nil, last
+	}
+	return nil, errNoServers
+}
+
+func (c *Cluster) execItemWithContext(ctx context.Context, key string, fn func(shardClient) (*mcturbo.Item, error)) (*mcturbo.Item, error) {
+	if c.closed.Load() {
+		return nil, ErrClosed
+	}
+	var last error
+	for _, cand := range c.pickCandidates(key) {
+		it, err := fn(cand.shard)
+		if err == nil {
+			c.noteSuccess(cand.addr)
+			return it, nil
+		}
+		last = err
+		c.noteFailure(cand.addr, err)
+		if !c.shouldTryNext(err) || ctx.Err() != nil {
+			return nil, err
+		}
+	}
+	if last != nil {
+		return nil, last
+	}
+	return nil, errNoServers
+}
+
+func (c *Cluster) execErrNoContext(key string, fn func(shardClient) error) error {
+	if c.closed.Load() {
+		return ErrClosed
+	}
+	var last error
+	for _, cand := range c.pickCandidates(key) {
+		err := fn(cand.shard)
+		if err == nil {
+			c.noteSuccess(cand.addr)
+			return nil
+		}
+		last = err
+		c.noteFailure(cand.addr, err)
+		if !c.shouldTryNext(err) {
+			return err
+		}
+	}
+	if last != nil {
+		return last
+	}
+	return errNoServers
+}
+
+func (c *Cluster) execErrWithContext(ctx context.Context, key string, fn func(shardClient) error) error {
+	if c.closed.Load() {
+		return ErrClosed
+	}
+	var last error
+	for _, cand := range c.pickCandidates(key) {
+		err := fn(cand.shard)
+		if err == nil {
+			c.noteSuccess(cand.addr)
+			return nil
+		}
+		last = err
+		c.noteFailure(cand.addr, err)
+		if !c.shouldTryNext(err) || ctx.Err() != nil {
+			return err
+		}
+	}
+	if last != nil {
+		return last
+	}
+	return errNoServers
+}
+
+func (c *Cluster) execUint64NoContext(key string, fn func(shardClient) (uint64, error)) (uint64, error) {
+	if c.closed.Load() {
+		return 0, ErrClosed
+	}
+	var last error
+	for _, cand := range c.pickCandidates(key) {
+		v, err := fn(cand.shard)
+		if err == nil {
+			c.noteSuccess(cand.addr)
+			return v, nil
+		}
+		last = err
+		c.noteFailure(cand.addr, err)
+		if !c.shouldTryNext(err) {
+			return 0, err
+		}
+	}
+	if last != nil {
+		return 0, last
+	}
+	return 0, errNoServers
+}
+
+func (c *Cluster) execUint64WithContext(ctx context.Context, key string, fn func(shardClient) (uint64, error)) (uint64, error) {
+	if c.closed.Load() {
+		return 0, ErrClosed
+	}
+	var last error
+	for _, cand := range c.pickCandidates(key) {
+		v, err := fn(cand.shard)
+		if err == nil {
+			c.noteSuccess(cand.addr)
+			return v, nil
+		}
+		last = err
+		c.noteFailure(cand.addr, err)
+		if !c.shouldTryNext(err) || ctx.Err() != nil {
+			return 0, err
+		}
+	}
+	if last != nil {
+		return 0, last
+	}
+	return 0, errNoServers
+}
+
+type shardCandidate struct {
+	addr  string
+	shard shardClient
+}
+
+func (c *Cluster) pickCandidates(key string) []shardCandidate {
+	if c.closed.Load() {
+		return nil
+	}
+	st := c.loadState()
+	if st == nil || st.router == nil || len(st.shards) == 0 {
+		return nil
+	}
+	start := st.router.Pick(key)
+	if start < 0 || start >= len(st.shards) {
+		return nil
+	}
+	if !c.removeFailedServers {
+		return []shardCandidate{{addr: st.servers[start].Addr, shard: st.shards[start]}}
+	}
+
+	now := time.Now()
+	out := make([]shardCandidate, 0, len(st.shards))
+	for i := 0; i < len(st.shards); i++ {
+		idx := (start + i) % len(st.shards)
+		addr := st.servers[idx].Addr
+		if !c.isAlive(addr, now) {
+			continue
+		}
+		out = append(out, shardCandidate{addr: addr, shard: st.shards[idx]})
+	}
+	if len(out) == 0 {
+		// all servers are currently ejected; fallback to all servers.
+		for i := 0; i < len(st.shards); i++ {
+			idx := (start + i) % len(st.shards)
+			out = append(out, shardCandidate{
+				addr:  st.servers[idx].Addr,
+				shard: st.shards[idx],
+			})
+		}
+	}
+	return out
+}
+
+func (c *Cluster) isAlive(addr string, now time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	h, ok := c.healthByAddr[addr]
+	if !ok {
+		return true
+	}
+	if h.deadUntil.IsZero() {
+		return true
+	}
+	if now.Before(h.deadUntil) {
+		return false
+	}
+	h.deadUntil = time.Time{}
+	h.failures = 0
+	return true
+}
+
+func (c *Cluster) noteSuccess(addr string) {
+	if !c.removeFailedServers {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	h, ok := c.healthByAddr[addr]
+	if !ok {
+		return
+	}
+	h.failures = 0
+	h.deadUntil = time.Time{}
+}
+
+func (c *Cluster) noteFailure(addr string, err error) {
+	if !c.removeFailedServers || !isCommunicationFailure(err) {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	h, ok := c.healthByAddr[addr]
+	if !ok {
+		h = &shardHealth{}
+		c.healthByAddr[addr] = h
+	}
+	h.failures++
+	if h.failures >= c.serverFailureLimit {
+		h.deadUntil = time.Now().Add(c.retryTimeout)
+		h.failures = 0
+	}
+}
+
+func (c *Cluster) shouldTryNext(err error) bool {
+	return c.removeFailedServers && isCommunicationFailure(err)
+}
+
+func isCommunicationFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, mcturbo.ErrNotFound) || errors.Is(err, mcturbo.ErrNotStored) || errors.Is(err, mcturbo.ErrCASConflict) {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	if nerr, ok := errors.AsType[net.Error](err); ok {
+		return nerr.Timeout() || !nerr.Temporary()
+	}
+	return mcturbo.IsProtocolError(err)
 }
 
 func validateServers(servers []Server) ([]Server, error) {

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -254,3 +254,14 @@ func TestValidateServers(t *testing.T) {
 		t.Fatalf("expected error for duplicate addr")
 	}
 }
+
+func TestFailoverOptionValidation(t *testing.T) {
+	_, err := NewCluster([]Server{{Addr: "127.0.0.1:1", Weight: 1}}, WithServerFailureLimit(0))
+	if err == nil {
+		t.Fatalf("expected error for invalid server failure limit")
+	}
+	_, err = NewCluster([]Server{{Addr: "127.0.0.1:1", Weight: 1}}, WithRetryTimeout(0))
+	if err == nil {
+		t.Fatalf("expected error for invalid retry timeout")
+	}
+}


### PR DESCRIPTION
This pull request introduces configurable failover and auto-eject behavior for clusters, allowing servers to be temporarily removed from the pool on communication errors, with customizable failure limits and retry timeouts. It also adds comprehensive tests to ensure correct failover logic and validates option inputs.

**Failover and Auto-Eject Feature:**
- Added `WithRemoveFailedServers`, `WithServerFailureLimit`, and `WithRetryTimeout` options to `cluster/options.go` to enable and configure temporary server removal after communication failures, including validation for their input values. [[1]](diffhunk://#diff-322ce121f830a2a52f07885d1c3102d920c54e32ce76ec3570bea60b0de6f5ceR45-R47) [[2]](diffhunk://#diff-322ce121f830a2a52f07885d1c3102d920c54e32ce76ec3570bea60b0de6f5ceR56-R58) [[3]](diffhunk://#diff-322ce121f830a2a52f07885d1c3102d920c54e32ce76ec3570bea60b0de6f5ceR119-R148)

**Testing and Validation:**
- Added tests in `cluster/cluster_more_test.go` to verify:
  - All-dead fallback triggers requests to all servers.
  - Failover occurs on communication errors (e.g., `io.EOF`) but not on semantic errors (e.g., `ErrNotFound`).
  - Servers are retried after the configured timeout.
- Added validation tests in `cluster/cluster_test.go` to ensure invalid failover options (e.g., zero failure limit or timeout) are rejected.

**Protocol Error Handling:**
- Introduced `IsProtocolError` helper in `client.go` to allow detection of protocol-level errors.

**Miscellaneous:**
- Updated imports in relevant files to support the new features and tests (adds `io` and `time` where needed). [[1]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeR7-R10) [[2]](diffhunk://#diff-322ce121f830a2a52f07885d1c3102d920c54e32ce76ec3570bea60b0de6f5ceR7)