### PR TITLE
add GetMulti and GetMultiWithContext to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It provides:
 Fast path (no context):
 - `Get(key string)`
 - `Gets(key string)`
+- `GetMulti(keys []string)`
 - `Set(key string, value []byte, flags uint32, ttlSeconds int)`
 - `Add(key string, value []byte, flags uint32, ttlSeconds int)`
 - `Replace(key string, value []byte, flags uint32, ttlSeconds int)`
@@ -36,7 +37,7 @@ Fast path (no context):
 Context-aware path:
 - `GetWithContext(ctx context.Context, key string)`
 - `GetsWithContext(ctx context.Context, key string)`
-- `GetMulti(ctx context.Context, keys []string)`
+- `GetMultiWithContext(ctx context.Context, keys []string)`
 - `SetWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int)`
 - `AddWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int)`
 - `ReplaceWithContext(ctx context.Context, key string, value []byte, flags uint32, ttlSeconds int)`
@@ -130,15 +131,18 @@ func main() {
 - `UpdateServers` may move keys.
 - Shards with unchanged `Addr` are reused.
 - Removed shards are closed.
-- Dead server auto-eject/remove-failed-servers is not implemented in this phase.
+- Dead server auto-eject is available via:
+  - `WithRemoveFailedServers(true)`
+  - `WithServerFailureLimit(n)`
+  - `WithRetryTimeout(d)`
 
 ### Cluster APIs
 
 Context-aware path:
-- `GetWithContext`, `SetWithContext`, `DeleteWithContext`, `TouchWithContext`
+- `GetWithContext`, `GetsWithContext`, `GetMultiWithContext`, `SetWithContext`, `DeleteWithContext`, `TouchWithContext`, `CASWithContext`
 
 Fast path:
-- `Get`, `Set`, `Add`, `Replace`, `Append`, `Prepend`, `Delete`, `Touch`, `GetAndTouch`, `Incr`, `Decr`
+- `Get`, `Gets`, `GetMulti`, `Set`, `Add`, `Replace`, `CAS`, `Append`, `Prepend`, `Delete`, `Touch`, `GetAndTouch`, `Incr`, `Decr`
 - Explicit aliases: `GetNoContext`, `GetsNoContext`, `SetNoContext`, `AddNoContext`, `ReplaceNoContext`, `CASNoContext`, `AppendNoContext`, `PrependNoContext`, `DeleteNoContext`, `TouchNoContext`, `GetAndTouchNoContext`, `IncrNoContext`, `DecrNoContext`
 
 Management:

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -25,6 +25,8 @@ type Server struct {
 type shardClient interface {
 	Get(key string) (*mcturbo.Item, error)
 	Gets(key string) (*mcturbo.Item, error)
+	GetMulti(keys []string) (map[string]*mcturbo.Item, error)
+	GetMultiWithContext(ctx context.Context, keys []string) (map[string]*mcturbo.Item, error)
 	Set(key string, value []byte, flags uint32, ttlSeconds int) error
 	Add(key string, value []byte, flags uint32, ttlSeconds int) error
 	Replace(key string, value []byte, flags uint32, ttlSeconds int) error
@@ -116,6 +118,68 @@ func (c *Cluster) Gets(key string) (*mcturbo.Item, error) {
 		return nil, err
 	}
 	return shard.Gets(key)
+}
+
+// GetMultiWithContext fetches multiple keys from routed shards using ctx.
+func (c *Cluster) GetMultiWithContext(ctx context.Context, keys []string) (map[string]*mcturbo.Item, error) {
+	out := make(map[string]*mcturbo.Item, len(keys))
+	if len(keys) == 0 {
+		return out, nil
+	}
+	if ctx == nil {
+		return out, errors.New("cluster: nil context")
+	}
+	if c.closed.Load() {
+		return out, ErrClosed
+	}
+	st := c.loadState()
+	if st == nil || st.router == nil || len(st.shards) == 0 {
+		return out, errNoServers
+	}
+
+	byShard := make(map[int][]string, len(st.shards))
+	for _, key := range keys {
+		idx := st.router.Pick(key)
+		if idx < 0 || idx >= len(st.shards) {
+			return out, errNoServers
+		}
+		byShard[idx] = append(byShard[idx], key)
+	}
+
+	type multiRes struct {
+		addr  string
+		items map[string]*mcturbo.Item
+		err   error
+	}
+	ch := make(chan multiRes, len(byShard))
+	for idx, grouped := range byShard {
+		shard := st.shards[idx]
+		addr := st.servers[idx].Addr
+		ks := append([]string(nil), grouped...)
+		go func() {
+			items, err := shard.GetMultiWithContext(ctx, ks)
+			ch <- multiRes{addr: addr, items: items, err: err}
+		}()
+	}
+
+	var merr *mcturbo.MultiError
+	for range byShard {
+		r := <-ch
+		if r.err != nil {
+			if merr == nil {
+				merr = &mcturbo.MultiError{PerServer: map[string]error{}}
+			}
+			merr.PerServer[r.addr] = r.err
+			continue
+		}
+		for k, v := range r.items {
+			out[k] = v
+		}
+	}
+	if merr != nil {
+		return out, merr
+	}
+	return out, nil
 }
 
 // Set stores value for key with flags and ttlSeconds.
@@ -342,6 +406,65 @@ func (c *Cluster) GetNoContext(key string) (*mcturbo.Item, error) {
 // GetsNoContext is an explicit no-context alias of Gets.
 func (c *Cluster) GetsNoContext(key string) (*mcturbo.Item, error) {
 	return c.Gets(key)
+}
+
+// GetMulti fetches multiple keys from routed shards without context.
+func (c *Cluster) GetMulti(keys []string) (map[string]*mcturbo.Item, error) {
+	out := make(map[string]*mcturbo.Item, len(keys))
+	if len(keys) == 0 {
+		return out, nil
+	}
+	if c.closed.Load() {
+		return out, ErrClosed
+	}
+	st := c.loadState()
+	if st == nil || st.router == nil || len(st.shards) == 0 {
+		return out, errNoServers
+	}
+
+	byShard := make(map[int][]string, len(st.shards))
+	for _, key := range keys {
+		idx := st.router.Pick(key)
+		if idx < 0 || idx >= len(st.shards) {
+			return out, errNoServers
+		}
+		byShard[idx] = append(byShard[idx], key)
+	}
+
+	type multiRes struct {
+		addr  string
+		items map[string]*mcturbo.Item
+		err   error
+	}
+	ch := make(chan multiRes, len(byShard))
+	for idx, grouped := range byShard {
+		shard := st.shards[idx]
+		addr := st.servers[idx].Addr
+		ks := append([]string(nil), grouped...)
+		go func() {
+			items, err := shard.GetMulti(ks)
+			ch <- multiRes{addr: addr, items: items, err: err}
+		}()
+	}
+
+	var merr *mcturbo.MultiError
+	for range byShard {
+		r := <-ch
+		if r.err != nil {
+			if merr == nil {
+				merr = &mcturbo.MultiError{PerServer: map[string]error{}}
+			}
+			merr.PerServer[r.addr] = r.err
+			continue
+		}
+		for k, v := range r.items {
+			out[k] = v
+		}
+	}
+	if merr != nil {
+		return out, merr
+	}
+	return out, nil
 }
 
 // SetNoContext is an explicit no-context alias of Set.

--- a/cluster/cluster_integration_test.go
+++ b/cluster/cluster_integration_test.go
@@ -147,6 +147,27 @@ func TestIntegrationModulaSetGet(t *testing.T) {
 	if string(v.Value) != "ybx" {
 		t.Fatalf("unexpected merged value: %q", string(v.Value))
 	}
+
+	if err := c.SetNoContext("cluster:modula:m1", []byte("mv1"), 1, 5); err != nil {
+		t.Fatalf("set m1: %v", err)
+	}
+	if err := c.SetNoContext("cluster:modula:m2", []byte("mv2"), 2, 5); err != nil {
+		t.Fatalf("set m2: %v", err)
+	}
+	m, err := c.GetMulti([]string{"cluster:modula:m1", "cluster:modula:m2", "cluster:modula:missing"})
+	if err != nil {
+		t.Fatalf("getmulti no context: %v", err)
+	}
+	if len(m) != 2 {
+		t.Fatalf("unexpected getmulti result size: %d", len(m))
+	}
+	m, err = c.GetMultiWithContext(ctx, []string{"cluster:modula:m1", "cluster:modula:m2"})
+	if err != nil {
+		t.Fatalf("getmulti with context: %v", err)
+	}
+	if len(m) != 2 {
+		t.Fatalf("unexpected getmulti(ctx) result size: %d", len(m))
+	}
 }
 
 func TestIntegrationConsistentSetGet(t *testing.T) {

--- a/cluster/cluster_more_test.go
+++ b/cluster/cluster_more_test.go
@@ -13,27 +13,29 @@ import (
 type fakeShard struct {
 	mu sync.Mutex
 
-	getCount                int
-	getsCount               int
-	setCount                int
-	addCount                int
-	replaceCount            int
-	appendCount             int
-	prependCount            int
-	deleteCount             int
-	touchCount              int
-	incrCount               int
-	decrCount               int
-	getWithContextCount     int
-	setWithContextCount     int
-	addWithContextCount     int
-	replaceWithContextCount int
-	appendWithContextCount  int
-	prependWithContextCount int
-	incrWithContextCount    int
-	decrWithContextCount    int
-	casCount                int
-	casWithContextCount     int
+	getCount                 int
+	getsCount                int
+	getMultiCount            int
+	getMultiWithContextCount int
+	setCount                 int
+	addCount                 int
+	replaceCount             int
+	appendCount              int
+	prependCount             int
+	deleteCount              int
+	touchCount               int
+	incrCount                int
+	decrCount                int
+	getWithContextCount      int
+	setWithContextCount      int
+	addWithContextCount      int
+	replaceWithContextCount  int
+	appendWithContextCount   int
+	prependWithContextCount  int
+	incrWithContextCount     int
+	decrWithContextCount     int
+	casCount                 int
+	casWithContextCount      int
 
 	getErr    error
 	setErr    error
@@ -67,6 +69,39 @@ func (s *fakeShard) Gets(key string) (*mcturbo.Item, error) {
 		return nil, s.getErr
 	}
 	return &mcturbo.Item{Value: append([]byte(nil), s.value...), CAS: 1}, nil
+}
+
+func (s *fakeShard) GetMultiWithContext(ctx context.Context, keys []string) (map[string]*mcturbo.Item, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getMultiWithContextCount++
+	s.last = "GetMultiWithContext"
+	if s.ctxErr != nil {
+		return nil, s.ctxErr
+	}
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	out := make(map[string]*mcturbo.Item, len(keys))
+	for _, k := range keys {
+		out[k] = &mcturbo.Item{Value: append([]byte(nil), s.value...)}
+	}
+	return out, nil
+}
+
+func (s *fakeShard) GetMulti(keys []string) (map[string]*mcturbo.Item, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getMultiCount++
+	s.last = "GetMultiNoContext"
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	out := make(map[string]*mcturbo.Item, len(keys))
+	for _, k := range keys {
+		out[k] = &mcturbo.Item{Value: append([]byte(nil), s.value...)}
+	}
+	return out, nil
 }
 
 func (s *fakeShard) Set(key string, value []byte, flags uint32, ttlSeconds int) error {
@@ -496,6 +531,63 @@ func TestClusterRoutingAndDelegation(t *testing.T) {
 	}
 	if target.addCount != 1 || target.replaceWithContextCount != 1 || target.appendCount != 1 || target.prependWithContextCount != 1 || target.casCount != 1 {
 		t.Fatalf("expected add/replace/append/prepend delegation on target")
+	}
+}
+
+func TestClusterGetMultiDelegation(t *testing.T) {
+	fakeByAddr := map[string]*fakeShard{}
+	factory := func(addr string, opts ...mcturbo.Option) (shardClient, error) {
+		s := &fakeShard{value: []byte("from-" + addr)}
+		fakeByAddr[addr] = s
+		return s, nil
+	}
+	servers := []Server{{Addr: "127.0.0.1:24001", Weight: 1}, {Addr: "127.0.0.1:24002", Weight: 1}}
+	c, err := NewCluster(servers, WithDistribution(DistributionModula), withTestFactory(factory))
+	if err != nil {
+		t.Fatalf("new cluster: %v", err)
+	}
+	defer c.Close()
+
+	st := c.loadState()
+	var k0, k1 string
+	for i := 0; i < 1000; i++ {
+		k := fmt.Sprintf("m%d", i)
+		idx := st.router.Pick(k)
+		if idx == 0 && k0 == "" {
+			k0 = k
+		}
+		if idx == 1 && k1 == "" {
+			k1 = k
+		}
+		if k0 != "" && k1 != "" {
+			break
+		}
+	}
+	if k0 == "" || k1 == "" {
+		t.Fatalf("failed to pick keys for both shards")
+	}
+
+	got, err := c.GetMulti([]string{k0, k1})
+	if err != nil {
+		t.Fatalf("GetMulti: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("unexpected item count: %d", len(got))
+	}
+	if fakeByAddr[servers[0].Addr].getMultiCount != 1 || fakeByAddr[servers[1].Addr].getMultiCount != 1 {
+		t.Fatalf("expected getmulti no-context to hit both shards once")
+	}
+
+	ctx := context.Background()
+	got, err = c.GetMultiWithContext(ctx, []string{k0, k1})
+	if err != nil {
+		t.Fatalf("GetMulti: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("unexpected item count: %d", len(got))
+	}
+	if fakeByAddr[servers[0].Addr].getMultiWithContextCount != 1 || fakeByAddr[servers[1].Addr].getMultiWithContextCount != 1 {
+		t.Fatalf("expected getmulti with context to hit both shards once")
 	}
 }
 


### PR DESCRIPTION
This pull request adds support for fetching multiple keys at once ("multi-get") in both context-aware and no-context forms for the client and cluster APIs. It introduces new `GetMulti` and `GetMultiWithContext` methods, updates the documentation and interfaces accordingly, and adds comprehensive tests to verify correct delegation, routing, and error handling for these new methods.

Key changes:

**API Additions and Documentation:**
- Added `GetMulti(keys []string)` and `GetMultiWithContext(ctx, keys)` methods to both the client and cluster APIs, allowing batch retrieval of multiple keys. Updated the `README.md` to document these new methods and their usage in both fast and context-aware paths. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R40) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L133-R145) [[4]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R28-R29)

**Client Implementation:**
- Implemented `GetMulti` (no context) in `client.go`, mirroring the logic of the context-aware version but without requiring a context. Added internal batching and error aggregation logic for both methods. Also introduced a new internal `getMultiFast` method for worker connections. [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL228-R235) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR296-R351) [[3]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR1057-R1090)

**Cluster Implementation:**
- Implemented `GetMulti` and `GetMultiWithContext` in the cluster, routing keys to the appropriate shards and aggregating results and errors. Updated the `shardClient` interface and provided implementations for both methods. [[1]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R123-R184) [[2]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R411-R469)

**Testing Enhancements:**
- Added and updated tests in `client_test.go` and `cluster/cluster_more_test.go` to cover both context-aware and no-context multi-get scenarios, including error cases and correct routing/delegation to shards. [[1]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3L556-R556) [[2]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3L610-R610) [[3]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3R625-R679) [[4]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3L678-R733) [[5]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3L722-R777) [[6]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeR18-R19) [[7]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeR74-R106) [[8]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeR537-R593) [[9]](diffhunk://#diff-7c1b719b760ff01236e64052990c7e4c746868b9f93b6997bb60c064570ca30eR150-R170)

**Internal Refactoring:**
- Updated the `fakeShard` test implementation and the `shardClient` interface to support and track calls to the new multi-get methods for improved test coverage and correctness. [[1]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeR18-R19) [[2]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeR74-R106)

These changes improve the efficiency and usability of the client and cluster APIs by enabling batch key retrieval, and ensure robust behavior through comprehensive testing.