### PR TITLE
add FlushAll and Ping APIs to cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,19 +131,29 @@ func main() {
 - `UpdateServers` may move keys.
 - Shards with unchanged `Addr` are reused.
 - Removed shards are closed.
-- Dead server auto-eject is available via:
-  - `WithRemoveFailedServers(true)`
-  - `WithServerFailureLimit(n)`
-  - `WithRetryTimeout(d)`
+- Optional failover (temporary auto-eject) is enabled by:
+  - `WithRemoveFailedServers(true)` (default: `false`)
+  - `WithServerFailureLimit(n)` (default: `2`)
+  - `WithRetryTimeout(d)` (default: `2s`)
+- Failover is only used for communication-level failures:
+  - network close (`io.EOF`, `net.ErrClosed`)
+  - timeout/non-temporary `net.Error`
+  - protocol parse errors (`mcturbo.IsProtocolError(err)`)
+- Failover is not used for semantic errors:
+  - `ErrNotFound`
+  - `ErrNotStored`
+  - `ErrCASConflict`
+- If all servers are temporarily ejected, the cluster falls back to trying all servers.
+- `GetMulti` keeps partial-success semantics (`result` and `error` can both be non-nil).
 
 ### Cluster APIs
 
 Context-aware path:
-- `GetWithContext`, `GetsWithContext`, `GetMultiWithContext`, `SetWithContext`, `DeleteWithContext`, `TouchWithContext`, `CASWithContext`
+- `GetWithContext`, `GetsWithContext`, `GetMultiWithContext`, `SetWithContext`, `AddWithContext`, `ReplaceWithContext`, `CASWithContext`, `AppendWithContext`, `PrependWithContext`, `DeleteWithContext`, `TouchWithContext`, `GetAndTouchWithContext`, `IncrWithContext`, `DecrWithContext`, `FlushAllWithContext`, `PingWithContext`
 
 Fast path:
-- `Get`, `Gets`, `GetMulti`, `Set`, `Add`, `Replace`, `CAS`, `Append`, `Prepend`, `Delete`, `Touch`, `GetAndTouch`, `Incr`, `Decr`
-- Explicit aliases: `GetNoContext`, `GetsNoContext`, `SetNoContext`, `AddNoContext`, `ReplaceNoContext`, `CASNoContext`, `AppendNoContext`, `PrependNoContext`, `DeleteNoContext`, `TouchNoContext`, `GetAndTouchNoContext`, `IncrNoContext`, `DecrNoContext`
+- `Get`, `Gets`, `GetMulti`, `Set`, `Add`, `Replace`, `CAS`, `Append`, `Prepend`, `Delete`, `Touch`, `GetAndTouch`, `Incr`, `Decr`, `FlushAll`, `Ping`
+- Explicit aliases: `GetNoContext`, `GetsNoContext`, `SetNoContext`, `AddNoContext`, `ReplaceNoContext`, `CASNoContext`, `AppendNoContext`, `PrependNoContext`, `DeleteNoContext`, `TouchNoContext`, `GetAndTouchNoContext`, `IncrNoContext`, `DecrNoContext`, `FlushAllNoContext`, `PingNoContext`
 
 Management:
 - `UpdateServers([]Server)`


### PR DESCRIPTION
This pull request adds new cluster-wide operations for flushing and pinging all shards, along with improved failover documentation and expanded test coverage. The main changes include implementing `FlushAll` and `Ping` methods (with both context-aware and no-context variants), updating the documentation to clarify failover behavior, and extending tests to verify these new features and failover scenarios.

**Cluster-wide Operations:**

* Added `FlushAll`, `Ping`, `FlushAllWithContext`, and `PingWithContext` methods to the `Cluster` type, enabling cluster-wide flush and connectivity checks. Also added explicit no-context aliases (`FlushAllNoContext`, `PingNoContext`). [[1]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R58-R61) [[2]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R370-R409) [[3]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R534-R543)
* Implemented helper methods `execAllNoContext` and `execAllWithContext` to perform actions across all shards, handling error aggregation and context cancellation.

**Documentation Updates:**

* Expanded the README to document the new cluster-wide APIs (`FlushAll`, `Ping`, and their context-aware variants) and clarified the failover mechanism, including which errors trigger failover and the fallback behavior when all servers are ejected.

**Testing Enhancements:**

* Added integration tests to verify the new `FlushAll` and `Ping` methods, both with and without context, and to ensure keys are properly flushed across the cluster.
* Added integration and helper tests for failover behavior in the presence of communication errors, ensuring that failover works as documented.
* Updated the `fakeShard` test double and unit tests to support and verify the new cluster-wide operations. [[1]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeR41-R44) [[2]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeR397-R440) [[3]](diffhunk://#diff-20d86aa0d0b6c133aa6e3bc9bd8058c085306b3b5baafd41cbbbc3db5e805efeR585-R603)